### PR TITLE
fix: 검색 자동 완성 페이징 로직 수정

### DIFF
--- a/src/main/java/com/funeat/product/application/ProductService.java
+++ b/src/main/java/com/funeat/product/application/ProductService.java
@@ -136,18 +136,20 @@ public class ProductService {
     }
 
     public SearchProductsResponse searchProducts(final String query, final Long lastProductId) {
-        final List<Product> products = findAllByNameContaining(query, lastProductId);
+        final List<Product> findProducts = findAllByNameContaining(query, lastProductId);
+        final int resultSize = getResultSize(findProducts);
+        final List<Product> products = findProducts.subList(0, resultSize);
 
-        final boolean hasNext = products.size() > DEFAULT_PAGE_SIZE;
+        final boolean hasNext = hasNextPage(findProducts);
         final List<SearchProductDto> productDtos = products.stream()
                 .map(SearchProductDto::toDto)
-                .collect(Collectors.toList());
+                .toList();
 
         return SearchProductsResponse.toResponse(hasNext, productDtos);
     }
 
     private List<Product> findAllByNameContaining(final String query, final Long lastProductId) {
-        final PageRequest size = PageRequest.ofSize(DEFAULT_PAGE_SIZE);
+        final PageRequest size = PageRequest.ofSize(DEFAULT_CURSOR_PAGINATION_SIZE);
         if (lastProductId == 0) {
             return productRepository.findAllByNameContainingFirst(query, size);
         }


### PR DESCRIPTION
## Issue

- close #13 

## ✨ 구현한 기능

- 검색 자동 완성 API에서 hasNext 관련 로직 수정
- 관련 검증 테스트 추가

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- 자바 버전 올린 기념으로 `.toList()`로 바꿔봤는데, 다른 메서드들에서도 쓴 거 다 바꾸면 코드 변경 많아질 거 같아서 이건 나중에 이슈 파서 한 번 수정하죠~

## ⏰ 일정

- 추정 시간 : 30min
- 걸린 시간 : 10min
