### PR TITLE
fix: cicd-be.yml 문법 에러 수정

### DIFF
--- a/.github/workflows/cicd-be.yml
+++ b/.github/workflows/cicd-be.yml
@@ -50,7 +50,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: [CI/CD] 백엔드 빌드 실패
+          author_name: "[CI/CD] 백엔드 빌드 실패"
           fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
         env:
           SLACK_COLOR: '#FF2D00'
@@ -90,7 +90,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: [CI/CD] 백엔드 배포 실패
+          author_name: "[CI/CD] 백엔드 배포 실패"
           fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
         env:
           SLACK_COLOR: '#FF2D00'
@@ -103,7 +103,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: [CI/CD] 백엔드 배포 성공
+          author_name: "[CI/CD] 백엔드 배포 성공"
           fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
         env:
           SLACK_COLOR: '#0019F4'


### PR DESCRIPTION
## Issue

- close #17 

## ✨ 구현한 기능

문법 에러가 발생하는 부분에 쌍따옴표를 붙여 문자열로 인식하게 만들었습니다.

## 📢 논의하고 싶은 내용

```
{, }, [, ], ,, &, *, #, ?, |, -, <, >, =, !, %, @, \
```
위와 같은 특수문자를 yaml에 사용하는 경우, 따옴표가 필요하다고 하네요

특수문자들이 yaml 문법에서 따로 행동하는게 있다고 합니다. ([참고 링크](https://yaml.org/spec/1.2.2/#53-indicator-characters))

그동안 다른 Actions나 이전 프로젝트에서 에러가 없었던 이유가 한글만 사용해서 그런거였네요


## ⏰ 일정

- 추정 시간 : 20분
- 걸린 시간 : 10분
