### PR TITLE
refactor: 상품 상세 정보에 카테고리 정보 추가

### DIFF
--- a/src/main/java/com/funeat/product/dto/CategoryDto.java
+++ b/src/main/java/com/funeat/product/dto/CategoryDto.java
@@ -1,0 +1,32 @@
+package com.funeat.product.dto;
+
+import com.funeat.product.domain.Category;
+
+public class CategoryDto {
+
+    private final Long id;
+    private final String name;
+    private final String image;
+
+    private CategoryDto(final Long id, final String name, final String image) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+    }
+
+    public static CategoryDto toDto(final Category category) {
+        return new CategoryDto(category.getId(), category.getName(), category.getImage());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImage() {
+        return image;
+    }
+}

--- a/src/main/java/com/funeat/product/dto/ProductResponse.java
+++ b/src/main/java/com/funeat/product/dto/ProductResponse.java
@@ -15,10 +15,11 @@ public class ProductResponse {
     private final String content;
     private final Double averageRating;
     private final Long reviewCount;
+    private final CategoryDto category;
     private final List<TagDto> tags;
 
     public ProductResponse(final Long id, final String name, final Long price, final String image, final String content,
-                           final Double averageRating, final Long reviewCount, final List<TagDto> tags) {
+                           final Double averageRating, final Long reviewCount, final CategoryDto category, final List<TagDto> tags) {
         this.id = id;
         this.name = name;
         this.price = price;
@@ -26,16 +27,18 @@ public class ProductResponse {
         this.content = content;
         this.averageRating = averageRating;
         this.reviewCount = reviewCount;
+        this.category = category;
         this.tags = tags;
     }
 
     public static ProductResponse toResponse(final Product product, final List<Tag> tags) {
-        List<TagDto> tagDtos = new ArrayList<>();
-        for (Tag tag : tags) {
+        final CategoryDto categoryDto = CategoryDto.toDto(product.getCategory());
+        final List<TagDto> tagDtos = new ArrayList<>();
+        for (final Tag tag : tags) {
             tagDtos.add(TagDto.toDto(tag));
         }
         return new ProductResponse(product.getId(), product.getName(), product.getPrice(), product.getImage(),
-                product.getContent(), product.getAverageRating(), product.getReviewCount(), tagDtos);
+                product.getContent(), product.getAverageRating(), product.getReviewCount(), categoryDto, tagDtos);
     }
 
     public Long getId() {
@@ -64,6 +67,10 @@ public class ProductResponse {
 
     public Long getReviewCount() {
         return reviewCount;
+    }
+
+    public CategoryDto getCategory() {
+        return category;
     }
 
     public List<TagDto> getTags() {

--- a/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -98,6 +98,7 @@ import com.funeat.product.dto.SearchProductDto;
 import com.funeat.product.dto.SearchProductResultDto;
 import com.funeat.product.dto.SearchProductResultsResponse;
 import com.funeat.product.dto.SearchProductsResponse;
+import com.funeat.product.dto.CategoryDto;
 import com.funeat.recipe.dto.RecipeDto;
 import com.funeat.tag.dto.TagDto;
 import io.restassured.response.ExtractableResponse;
@@ -673,6 +674,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
     private void 상품_상세_정보_조회_결과를_검증한다(final ExtractableResponse<Response> response) {
         final var actual = response.as(ProductResponse.class);
+        final var actualCategory = response.jsonPath().getObject("category", CategoryDto.class);
         final var actualTags = response.jsonPath()
                 .getList("tags", TagDto.class);
 
@@ -684,6 +686,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
             soft.assertThat(actual.getContent()).isEqualTo("맛있는 삼각김밥");
             soft.assertThat(actual.getAverageRating()).isEqualTo(3.0);
             soft.assertThat(actual.getReviewCount()).isEqualTo(3L);
+            soft.assertThat(actualCategory.getName()).isEqualTo("간편식사");
             soft.assertThat(actualTags).extracting("id").containsExactly(2L, 1L);
         });
     }


### PR DESCRIPTION
## Issue

- close #28 

## ✨ 구현한 기능

![image](https://github.com/fun-eat/funeat-server/assets/79046106/eb6f6605-4122-4ea0-be37-71c50122d90d)

- 위에 어느 편의점 상품인지 확인할 수 있도록 카테고리 정보를 추가했습니다.

- `Category`에 대한 DTO가 `CategoryResponse`만 존재해서 `CategoryDto`를 만들었습니다.

## 📢 논의하고 싶은 내용

.

## 🎸 기타

- 노션 문서 수정 완료 (상품 상세 정보 조회)

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 0.25
