### PR TITLE
fix: 최신순으로 리뷰를 조회하는 쿼리문 수정

### DIFF
--- a/src/main/java/com/funeat/review/specification/SortingReviewSpecification.java
+++ b/src/main/java/com/funeat/review/specification/SortingReviewSpecification.java
@@ -87,7 +87,8 @@ public final class SortingReviewSpecification {
         if (LOCALDATETIME_TYPE_INCLUDE.contains(fieldName)) {
             final Path<LocalDateTime> createdAtPath = root.get(fieldName);
             final LocalDateTime lastReviewCreatedAt = lastReview.getCreatedAt();
-            return criteriaBuilder.equal(createdAtPath, lastReviewCreatedAt);
+            final int reformatNano = Math.round((float) lastReviewCreatedAt.getNano() / 1000) * 1000;
+            return criteriaBuilder.equal(createdAtPath, lastReviewCreatedAt.withNano(reformatNano));
         }
         if (LONG_TYPE_INCLUDE.contains(fieldName)) {
             final Path<Long> reviewPath = root.get(fieldName);
@@ -120,7 +121,8 @@ public final class SortingReviewSpecification {
         if (LOCALDATETIME_TYPE_INCLUDE.contains(fieldName)) {
             final Path<LocalDateTime> createdAtPath = root.get(fieldName);
             final LocalDateTime lastReviewCreatedAt = lastReview.getCreatedAt();
-            return criteriaBuilder.greaterThan(createdAtPath, lastReviewCreatedAt);
+            final int reformatNano = Math.round((float) lastReviewCreatedAt.getNano() / 1000) * 1000;
+            return criteriaBuilder.greaterThan(createdAtPath, lastReviewCreatedAt.withNano(reformatNano));
         }
         if (LONG_TYPE_INCLUDE.contains(fieldName)) {
             final Path<Long> reviewPath = root.get(fieldName);
@@ -149,7 +151,8 @@ public final class SortingReviewSpecification {
         if (LOCALDATETIME_TYPE_INCLUDE.contains(fieldName)) {
             final Path<LocalDateTime> createdAtPath = root.get(fieldName);
             final LocalDateTime lastReviewCreatedAt = lastReview.getCreatedAt();
-            return criteriaBuilder.lessThan(createdAtPath, lastReviewCreatedAt);
+            final int reformatNano = Math.round((float) lastReviewCreatedAt.getNano() / 1000) * 1000;
+            return criteriaBuilder.lessThan(createdAtPath, lastReviewCreatedAt.withNano(reformatNano));
         }
         if (LONG_TYPE_INCLUDE.contains(fieldName)) {
             final Path<Long> reviewPath = root.get(fieldName);

--- a/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -386,9 +386,7 @@ class ReviewServiceTest extends ServiceTest {
             final var productId = 단일_상품_저장(product);
 
             final var review1 = 리뷰_이미지test3_평점3점_재구매O_생성(member, product, 351L);
-            Thread.sleep(100);
             final var review2 = 리뷰_이미지test4_평점4점_재구매O_생성(member, product, 24L);
-            Thread.sleep(100);
             final var review3 = 리뷰_이미지test3_평점3점_재구매X_생성(member, product, 130L);
             복수_리뷰_저장(review1, review2, review3);
 


### PR DESCRIPTION
## Issue

- close #33

## ✨ 구현한 기능

- 최신순으로 리뷰를 정렬하는 `created_at` 값을 데이터베이스에 맞게 microseconds로 단위를 수정했습니다.
- 테스트 코드에 있는 `Thread.sleep(...)`을 삭제 했습니다.

## 📢 논의하고 싶은 내용

- .

## 🎸 기타

삽질을 해보면서 확인해보니 `복수_리뷰_저장(...)` 이후 `entityManager.clear()`를 호출하냐, 안하냐에 따라서 쿼리문이 달라집니다.

1. `entityManager.clear()`를 호출하지 않았을 경우

![스크린샷 2024-04-03 오전 12 14 00](https://github.com/fun-eat/funeat-server/assets/79046106/08309083-ba25-4c5c-983b-92116c96579e)

검색 쿼리문에 들어가는 영속성 컨텍스트의 1차 캐시에 있던 `review3`이 그대로 재사용됩니다. 로그 살펴보면 리뷰에 대한 select문 없이 insert문만 존재합니다.
(인텔리제이에서 디버그 모드로 실행해보면 완전히 같은 객체임을 확인 가능함)


2. `entityManager.clear()`를 호출 했을 경우

![스크린샷 2024-04-03 오전 12 16 39](https://github.com/fun-eat/funeat-server/assets/79046106/45a33bb6-bfb8-4dfe-88de-7e9c1d902b8c)

이때는 1차 캐시를 지웠으니 당연히 디비에 있는 값을 꺼내옵니다. 로그를 살펴보면 리뷰에 대한 select문이 존재합니다.


### ?. 소수점 9자리와 소수점 6자리 차이가 나는 이유


![스크린샷 2024-04-03 오전 12 20 35](https://github.com/fun-eat/funeat-server/assets/79046106/f66cd63c-59c9-45a3-84cb-8f4d41192a62)

Java의 LocalDateTime은 LocalDate와 LocalTime을 합쳐서 사용합니다.

![스크린샷 2024-04-03 오전 12 19 45](https://github.com/fun-eat/funeat-server/assets/79046106/1983e18c-9045-4ed6-9d98-baea629316d4)

LocalTime 값을 확인해보면 nanoseconds가 9자리의 수까지 가능합니다.

![스크린샷 2024-04-03 오전 12 22 10](https://github.com/fun-eat/funeat-server/assets/79046106/83ec903b-5696-4a66-8a1f-f2c4cb7a922c)

H2 공식 문서를 보면 TIMESTAMP는 소수점 0자리 수부터 9자리 수까지 제공하지만, 기본값은 6입니다.

![스크린샷 2024-04-03 오전 12 23 10](https://github.com/fun-eat/funeat-server/assets/79046106/b39b34dd-6cbf-4f88-9163-5dc9a7d185d8)

테이블 생성 쿼리를 확인해보면 TIMESTAMP(6)으로 저장하는 것을 확인할 수 있습니다.

![image](https://github.com/fun-eat/funeat-server/assets/79046106/f409d607-4306-4b7c-a9d7-56acc96fc06e)

참고로 MySQL 공식문서도 최대 소수점 아래 6자리까지만 지원한다고 나와있습니다.

### 테스트가 실패하는 이유

1차 캐시에서 가져오는 값은 26.362916145초이지만, 디비에서 가져오는 값은 26.362916초이기 때문에 쿼리문은 `26.362916145 > created_at (26.362916)`으로 동작하므로 자기자신의 값까지 가져오게 됩니다.

현재 서비스에서는 리뷰 작성 API, 리뷰 조회 API 가 분리되어 서로 다른 트랜잭션을 사용하지만, 테스트 코드 한정에서만 같은 트랜잭션 범위 내에서 저장과 조회가 동작하여 발생하는 문제입니다.

### 테스트가 성공하는 이유

![스크린샷 2024-04-03 오전 12 34 18](https://github.com/fun-eat/funeat-server/assets/79046106/1b3a1091-7827-4049-bf88-cf5835430023)

H2 공식문서에서 설정된 값보다 더 깊이 들어간 소수점 자리수는 반올림을 한다고 나와있습니다.

- 실제 값: 26.362909999초
- 저장 값: 26.362910초

위와 같이 적용되기 때문에 `26.362909999 > created_at (26.362910)`는 성립하지 않으므로 정상적인 값이 나오게 됩니다.

## ⏰ 일정

- 추정 시간 : 코드 삭제하려고 했음
- 걸린 시간 : 하루
