### PR TITLE
refactor: 꿀조합 랭킹 API 수정

### DIFF
--- a/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
+++ b/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
@@ -1,9 +1,9 @@
 package com.funeat.auth.util;
 
 import com.funeat.auth.dto.LoginInfo;
-import java.util.Objects;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -13,6 +13,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final LoginInfo GUEST = new LoginInfo(-1L);
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -24,8 +26,11 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         final HttpSession session = Objects.requireNonNull(request).getSession(false);
-        final String id = String.valueOf(session.getAttribute("member"));
+        if (Objects.isNull(session)) {
+            return GUEST;
+        }
 
+        final String id = String.valueOf(session.getAttribute("member"));
         return new LoginInfo(Long.valueOf(id));
     }
 }

--- a/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -28,6 +28,7 @@ import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
 import com.funeat.recipe.dto.RankingRecipeDto;
 import com.funeat.recipe.dto.RankingRecipesResponse;
+import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCommentCondition;
 import com.funeat.recipe.dto.RecipeCommentCreateRequest;
 import com.funeat.recipe.dto.RecipeCommentResponse;
@@ -230,15 +231,16 @@ public class RecipeService {
 
     private RankingRecipeDto createRankingRecipeDto(final Long memberId, final Recipe recipe) {
         final List<RecipeImage> findRecipeImages = recipeImageRepository.findByRecipe(recipe);
+        final RecipeAuthorDto author = RecipeAuthorDto.toDto(recipe.getMember());
 
         if (memberId == GUEST_ID) {
-            return RankingRecipeDto.toDto(recipe, findRecipeImages, false);
+            return RankingRecipeDto.toDto(recipe, findRecipeImages, author, false);
         }
 
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
         final boolean favorite = recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(member, recipe);
-        return RankingRecipeDto.toDto(recipe, findRecipeImages, favorite);
+        return RankingRecipeDto.toDto(recipe, findRecipeImages, author, favorite);
     }
 
     @Transactional

--- a/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -28,7 +28,6 @@ import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
 import com.funeat.recipe.dto.RankingRecipeDto;
 import com.funeat.recipe.dto.RankingRecipesResponse;
-import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCommentCondition;
 import com.funeat.recipe.dto.RecipeCommentCreateRequest;
 import com.funeat.recipe.dto.RecipeCommentResponse;
@@ -63,10 +62,11 @@ import org.springframework.web.multipart.MultipartFile;
 public class RecipeService {
 
     private static final long RANKING_MINIMUM_FAVORITE_COUNT = 1L;
-    private static final int RANKING_SIZE = 3;
+    private static final int RANKING_SIZE = 4;
     private static final int DEFAULT_PAGE_SIZE = 10;
     private static final int RECIPE_COMMENT_PAGE_SIZE = 10;
     private static final int DEFAULT_CURSOR_PAGINATION_SIZE = 11;
+    private static final long GUEST_ID = -1L;
 
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
@@ -217,19 +217,28 @@ public class RecipeService {
         return recipeRepository.findAllByProductNameContaining(query, lastRecipeId, size);
     }
 
-    public RankingRecipesResponse getTop3Recipes() {
+    public RankingRecipesResponse getTop4Recipes(final Long memberId) {
         final List<Recipe> recipes = recipeRepository.findRecipesByFavoriteCountGreaterThanEqual(RANKING_MINIMUM_FAVORITE_COUNT);
 
         final List<RankingRecipeDto> dtos = recipes.stream()
                 .sorted(Comparator.comparing(Recipe::calculateRankingScore).reversed())
                 .limit(RANKING_SIZE)
-                .map(recipe -> {
-                    final List<RecipeImage> findRecipeImages = recipeImageRepository.findByRecipe(recipe);
-                    final RecipeAuthorDto author = RecipeAuthorDto.toDto(recipe.getMember());
-                    return RankingRecipeDto.toDto(recipe, findRecipeImages, author);
-                })
-                .collect(Collectors.toList());
+                .map(recipe -> createRankingRecipeDto(memberId, recipe))
+                .toList();
         return RankingRecipesResponse.toResponse(dtos);
+    }
+
+    private RankingRecipeDto createRankingRecipeDto(final Long memberId, final Recipe recipe) {
+        final List<RecipeImage> findRecipeImages = recipeImageRepository.findByRecipe(recipe);
+
+        if (memberId == GUEST_ID) {
+            return RankingRecipeDto.toDto(recipe, findRecipeImages, false);
+        }
+
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
+        final boolean favorite = recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(member, recipe);
+        return RankingRecipeDto.toDto(recipe, findRecipeImages, favorite);
     }
 
     @Transactional

--- a/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
@@ -10,12 +10,12 @@ public class RankingRecipeDto {
     private final Long id;
     private final String image;
     private final String title;
-    private final RecipeAuthorDto author;
-    private final Long favoriteCount;
+    private final String author;
+    private final Boolean favoriteCount;
     private final LocalDateTime createdAt;
 
-    public RankingRecipeDto(final Long id, final String image, final String title, final RecipeAuthorDto author,
-                            final Long favoriteCount, final LocalDateTime createdAt) {
+    public RankingRecipeDto(final Long id, final String image, final String title, final String author,
+                            final Boolean favoriteCount, final LocalDateTime createdAt) {
         this.id = id;
         this.image = image;
         this.title = title;
@@ -24,14 +24,13 @@ public class RankingRecipeDto {
         this.createdAt = createdAt;
     }
 
-    public static RankingRecipeDto toDto(final Recipe recipe, final List<RecipeImage> images,
-                                         final RecipeAuthorDto author) {
+    public static RankingRecipeDto toDto(final Recipe recipe, final List<RecipeImage> images, final Boolean favorite) {
         if (images.isEmpty()) {
-            return new RankingRecipeDto(recipe.getId(), null, recipe.getTitle(), author,
-                    recipe.getFavoriteCount(), recipe.getCreatedAt());
+            return new RankingRecipeDto(recipe.getId(), null, recipe.getTitle(),
+                    recipe.getMember().getNickname(), favorite, recipe.getCreatedAt());
         }
-        return new RankingRecipeDto(recipe.getId(), images.get(0).getImage(), recipe.getTitle(), author,
-                recipe.getFavoriteCount(), recipe.getCreatedAt());
+        return new RankingRecipeDto(recipe.getId(), images.get(0).getImage(), recipe.getTitle(),
+                recipe.getMember().getNickname(), favorite, recipe.getCreatedAt());
     }
 
     public Long getId() {
@@ -46,11 +45,11 @@ public class RankingRecipeDto {
         return title;
     }
 
-    public RecipeAuthorDto getAuthor() {
+    public String getAuthor() {
         return author;
     }
 
-    public Long getFavoriteCount() {
+    public Boolean getFavoriteCount() {
         return favoriteCount;
     }
 

--- a/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
@@ -11,16 +11,16 @@ public class RankingRecipeDto {
     private final String image;
     private final String title;
     private final String author;
-    private final Boolean favoriteCount;
+    private final Boolean favorite;
     private final LocalDateTime createdAt;
 
     public RankingRecipeDto(final Long id, final String image, final String title, final String author,
-                            final Boolean favoriteCount, final LocalDateTime createdAt) {
+                            final Boolean favorite, final LocalDateTime createdAt) {
         this.id = id;
         this.image = image;
         this.title = title;
         this.author = author;
-        this.favoriteCount = favoriteCount;
+        this.favorite = favorite;
         this.createdAt = createdAt;
     }
 
@@ -49,8 +49,8 @@ public class RankingRecipeDto {
         return author;
     }
 
-    public Boolean getFavoriteCount() {
-        return favoriteCount;
+    public Boolean getFavorite() {
+        return favorite;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
@@ -10,11 +10,11 @@ public class RankingRecipeDto {
     private final Long id;
     private final String image;
     private final String title;
-    private final String author;
+    private final RecipeAuthorDto author;
     private final Boolean favorite;
     private final LocalDateTime createdAt;
 
-    public RankingRecipeDto(final Long id, final String image, final String title, final String author,
+    public RankingRecipeDto(final Long id, final String image, final String title, final RecipeAuthorDto author,
                             final Boolean favorite, final LocalDateTime createdAt) {
         this.id = id;
         this.image = image;
@@ -24,13 +24,14 @@ public class RankingRecipeDto {
         this.createdAt = createdAt;
     }
 
-    public static RankingRecipeDto toDto(final Recipe recipe, final List<RecipeImage> images, final Boolean favorite) {
+    public static RankingRecipeDto toDto(final Recipe recipe, final List<RecipeImage> images,
+                                         final RecipeAuthorDto author, final Boolean favorite) {
         if (images.isEmpty()) {
-            return new RankingRecipeDto(recipe.getId(), null, recipe.getTitle(),
-                    recipe.getMember().getNickname(), favorite, recipe.getCreatedAt());
+            return new RankingRecipeDto(recipe.getId(), null, recipe.getTitle(), author, favorite,
+                    recipe.getCreatedAt());
         }
-        return new RankingRecipeDto(recipe.getId(), images.get(0).getImage(), recipe.getTitle(),
-                recipe.getMember().getNickname(), favorite, recipe.getCreatedAt());
+        return new RankingRecipeDto(recipe.getId(), images.get(0).getImage(), recipe.getTitle(), author, favorite,
+                recipe.getCreatedAt());
     }
 
     public Long getId() {
@@ -45,7 +46,7 @@ public class RankingRecipeDto {
         return title;
     }
 
-    public String getAuthor() {
+    public RecipeAuthorDto getAuthor() {
         return author;
     }
 

--- a/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -13,10 +13,9 @@ import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.dto.RecipeFavoriteRequest;
 import com.funeat.recipe.dto.SearchRecipeResultsResponse;
 import com.funeat.recipe.dto.SortingRecipesResponse;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
-import jakarta.validation.Valid;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
@@ -78,8 +77,8 @@ public class RecipeApiController implements RecipeController {
     }
 
     @GetMapping("/api/ranks/recipes")
-    public ResponseEntity<RankingRecipesResponse> getRankingRecipes() {
-        final RankingRecipesResponse response = recipeService.getTop3Recipes();
+    public ResponseEntity<RankingRecipesResponse> getRankingRecipes(@AuthenticationPrincipal final LoginInfo loginInfo) {
+        final RankingRecipesResponse response = recipeService.getTop4Recipes(loginInfo.getId());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/funeat/recipe/presentation/RecipeController.java
+++ b/src/main/java/com/funeat/recipe/presentation/RecipeController.java
@@ -68,13 +68,13 @@ public interface RecipeController {
                                     @PathVariable final Long recipeId,
                                     @RequestBody final RecipeFavoriteRequest request);
 
-    @Operation(summary = "꿀조합 랭킹 조회", description = "전체 꿀조합들 중에서 랭킹 TOP3를 조회한다.")
+    @Operation(summary = "꿀조합 랭킹 조회", description = "전체 꿀조합들 중에서 랭킹 TOP4를 조회한다.")
     @ApiResponse(
             responseCode = "200",
             description = "꿀조합 랭킹 조회 성공."
     )
     @GetMapping
-    ResponseEntity<RankingRecipesResponse> getRankingRecipes();
+    ResponseEntity<RankingRecipesResponse> getRankingRecipes(@AuthenticationPrincipal final LoginInfo loginInfo);
 
     @Operation(summary = "꿀조합 검색 결과 조회", description = "검색어가 포함된 상품이 있는 꿀조합 목록을 조회한다.")
     @ApiResponse(

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -68,8 +68,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.funeat.acceptance.common.AcceptanceTest;
-import com.funeat.member.domain.Member;
-import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.dto.DetailProductRecipeDto;
 import com.funeat.recipe.dto.RankingRecipeDto;
 import com.funeat.recipe.dto.RecipeAuthorDto;
@@ -84,7 +82,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -768,12 +765,6 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             soft.assertThat(response.jsonPath().getString("message"))
                     .isEqualTo(expectedMessage);
         });
-    }
-
-    private List<RankingRecipeDto> 예상_레시피_랭킹_변환(final List<Recipe> recipes, final Member member) {
-        return recipes.stream()
-                .map(it -> RankingRecipeDto.toDto(it, Collections.emptyList(), RecipeAuthorDto.toDto(member)))
-                .collect(Collectors.toList());
     }
 
     private void 레시피_랭킹_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<Long> recipeIds) {

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -524,7 +524,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     class getRankingRecipes_성공_테스트 {
 
         @Test
-        void 전체_꿀조합들_중에서_랭킹_TOP3를_조회할_수_있다() {
+        void 전체_꿀조합들_중에서_랭킹_TOP4를_조회할_수_있다() {
             // given
             final var 카테고리 = 카테고리_간편식사_생성();
             단일_카테고리_저장(카테고리);
@@ -534,8 +534,9 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지2), 레시피추가요청_생성(상품));
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지3), 레시피추가요청_생성(상품));
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지4), 레시피추가요청_생성(상품));
+            여러명이_레시피_좋아요_요청(List.of(멤버1), 레시피1, 좋아요O);
             여러명이_레시피_좋아요_요청(List.of(멤버1, 멤버2), 레시피2, 좋아요O);
-            여러명이_레시피_좋아요_요청(List.of(멤버1), 레시피3, 좋아요O);
+            여러명이_레시피_좋아요_요청(List.of(멤버1, 멤버2), 레시피3, 좋아요O);
             여러명이_레시피_좋아요_요청(List.of(멤버1, 멤버2, 멤버3), 레시피4, 좋아요O);
 
             // when
@@ -543,7 +544,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리);
-            레시피_랭킹_조회_결과를_검증한다(응답, List.of(레시피4, 레시피2, 레시피3));
+            레시피_랭킹_조회_결과를_검증한다(응답, List.of(레시피4, 레시피2, 레시피3, 레시피1));
         }
     }
 

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -83,6 +83,15 @@ public class RecipeSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 레시피_랭킹_조회_요청(final String loginCookie) {
+        return given()
+                .cookie("SESSION", loginCookie)
+                .when()
+                .get("/api/ranks/recipes")
+                .then()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 레시피_검색_결과_조회_요청(final String query, final Long lastRecipeId) {
         return given()
                 .queryParam("query", query)

--- a/src/test/java/com/funeat/common/ServiceTest.java
+++ b/src/test/java/com/funeat/common/ServiceTest.java
@@ -7,6 +7,7 @@ import com.funeat.banner.persistence.BannerRepository;
 import com.funeat.comment.persistence.CommentRepository;
 import com.funeat.member.application.TestMemberService;
 import com.funeat.member.domain.Member;
+import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.RecipeFavoriteRepository;
@@ -204,6 +205,10 @@ public abstract class ServiceTest {
         final var productRecipes = List.of(productRecipeImageToSave);
 
         productRecipeRepository.saveAll(productRecipes);
+    }
+
+    protected void 단일_꿀조합_좋아요_저장(final RecipeFavorite recipeFavorite) {
+        recipeFavoriteRepository.save(recipeFavorite);
     }
 
     protected void 복수_배너_저장(final Banner... bannerToSave) {

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -557,7 +557,7 @@ class RecipeServiceTest extends ServiceTest {
     }
 
     @Nested
-    class getTop3Recipes_성공_테스트 {
+    class getTop4Recipes_성공_테스트 {
 
         @Nested
         class 꿀조합_개수에_대한_테스트 {

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -39,7 +39,6 @@ import com.funeat.product.domain.Product;
 import com.funeat.product.exception.ProductException.ProductNotFoundException;
 import com.funeat.recipe.dto.RankingRecipeDto;
 import com.funeat.recipe.dto.RankingRecipesResponse;
-import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCommentCondition;
 import com.funeat.recipe.dto.RecipeCommentCreateRequest;
 import com.funeat.recipe.dto.RecipeCommentResponse;
@@ -761,7 +760,6 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 10L, now.minusDays(4L));
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var author = RecipeAuthorDto.toDto(member);
                 final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
                 final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
@@ -787,7 +785,6 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 4L, now.minusDays(1L));
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var author = RecipeAuthorDto.toDto(member);
                 final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
                 final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -17,6 +17,7 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점3점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000원_평점4점_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_생성;
+import static com.funeat.fixture.RecipeFixture.레시피_좋아요_생성;
 import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
 import static com.funeat.fixture.RecipeFixture.레시피좋아요요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피추가요청_생성;
@@ -665,6 +666,71 @@ class RecipeServiceTest extends ServiceTest {
                 복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
 
                 final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
+                final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
+
+                // when
+                final var actual = recipeService.getTop4Recipes(loginId);
+
+                // then
+                assertThat(actual).usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class 로그인_여부_응답_테스트 {
+
+            @Test
+            void 로그인_안한_경우_꿀조합의_좋아요는_false로_반환한다() {
+                // given
+                final var loginId = -1L;
+                final var member = 멤버_멤버1_생성();
+                단일_멤버_저장(member);
+
+                final var now = LocalDateTime.now();
+                final var recipe1 = 레시피_생성(member, 4L, now.minusDays(10L));
+                final var recipe2 = 레시피_생성(member, 6L, now.minusDays(10L));
+                final var recipe3 = 레시피_생성(member, 5L, now);
+                final var recipe4 = 레시피_생성(member, 6L, now);
+                복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
+
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
+                final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
+
+                // when
+                final var actual = recipeService.getTop4Recipes(loginId);
+
+                // then
+                assertThat(actual).usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+
+            @Test
+            void 로그인_한_경우_꿀조합의_좋아요는_로그인_사용자의_좋아요_여부로_반환한다() {
+                // given
+                final var member = 멤버_멤버1_생성();
+                단일_멤버_저장(member);
+                final var loginId = member.getId();
+
+                final var now = LocalDateTime.now();
+                final var recipe1 = 레시피_생성(member, 4L, now.minusDays(10L));
+                final var recipe2 = 레시피_생성(member, 6L, now.minusDays(10L));
+                final var recipe3 = 레시피_생성(member, 5L, now);
+                final var recipe4 = 레시피_생성(member, 6L, now);
+                복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
+
+                final var recipeFavorite = 레시피_좋아요_생성(member, recipe1, true);
+                단일_꿀조합_좋아요_저장(recipeFavorite);
+
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), true);
                 final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
                 final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -564,11 +564,11 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 전체_꿀조합이_하나도_없어도_반환값은_있어야한다() {
                 // given
-                final var guestId = -1L;
+                final var loginId = -1L;
                 final var expected = RankingRecipesResponse.toResponse(Collections.emptyList());
 
                 // when
-                final var actual = recipeService.getTop4Recipes(guestId);
+                final var actual = recipeService.getTop4Recipes(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -578,7 +578,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 랭킹_조건에_부합하는_꿀조합이_1개면_꿀조합이_1개_반환된다() {
                 // given
-                final var guestId = -1L;
+                final var loginId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -586,13 +586,12 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe = 레시피_생성(member, 2L, now);
                 단일_꿀조합_저장(recipe);
 
-                final var author = RecipeAuthorDto.toDto(member);
                 final var rankingRecipeDto = RankingRecipeDto.toDto(recipe, Collections.emptyList(), false);
                 final var rankingRecipesDtos = Collections.singletonList(rankingRecipeDto);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop4Recipes(guestId);
+                final var actual = recipeService.getTop4Recipes(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -602,7 +601,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 랭킹_조건에_부합하는_꿀조합이_2개면_꿀조합이_2개_반환된다() {
                 // given
-                final var guestId = -1L;
+                final var loginId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -611,14 +610,40 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 2L, now);
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var author = RecipeAuthorDto.toDto(member);
                 final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
                 final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop4Recipes(guestId);
+                final var actual = recipeService.getTop4Recipes(loginId);
+
+                // then
+                assertThat(actual).usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+
+            @Test
+            void 랭킹_조건에_부합하는_꿀조합이_3개면_꿀조합이_3개_반환된다() {
+                // given
+                final var loginId = -1L;
+                final var member = 멤버_멤버1_생성();
+                단일_멤버_저장(member);
+
+                final var now = LocalDateTime.now();
+                final var recipe1 = 레시피_생성(member, 2L, now.minusDays(2L));
+                final var recipe2 = 레시피_생성(member, 2L, now.minusDays(1L));
+                final var recipe3 = 레시피_생성(member, 2L, now);
+                복수_꿀조합_저장(recipe1, recipe2, recipe3);
+
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
+                final var rankingRecipesDtos = List.of(rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
+                final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
+
+                // when
+                final var actual = recipeService.getTop4Recipes(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -628,7 +653,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 전체_꿀조합_중_랭킹이_높은_상위_4개_꿀조합을_구할_수_있다() {
                 // given
-                final var guestId = -1L;
+                final var loginId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -639,7 +664,6 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe4 = 레시피_생성(member, 6L, now);
                 복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
 
-                final var author = RecipeAuthorDto.toDto(member);
                 final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
                 final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
@@ -648,7 +672,7 @@ class RecipeServiceTest extends ServiceTest {
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop4Recipes(guestId);
+                final var actual = recipeService.getTop4Recipes(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -564,10 +564,11 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 전체_꿀조합이_하나도_없어도_반환값은_있어야한다() {
                 // given
+                final var guestId = -1L;
                 final var expected = RankingRecipesResponse.toResponse(Collections.emptyList());
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -577,6 +578,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 랭킹_조건에_부합하는_꿀조합이_1개면_꿀조합이_1개_반환된다() {
                 // given
+                final var guestId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -585,12 +587,12 @@ class RecipeServiceTest extends ServiceTest {
                 단일_꿀조합_저장(recipe);
 
                 final var author = RecipeAuthorDto.toDto(member);
-                final var rankingRecipeDto = RankingRecipeDto.toDto(recipe, Collections.emptyList(), author);
+                final var rankingRecipeDto = RankingRecipeDto.toDto(recipe, Collections.emptyList(), false);
                 final var rankingRecipesDtos = Collections.singletonList(rankingRecipeDto);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -600,6 +602,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 랭킹_조건에_부합하는_꿀조합이_2개면_꿀조합이_2개_반환된다() {
                 // given
+                final var guestId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -609,13 +612,13 @@ class RecipeServiceTest extends ServiceTest {
                 복수_꿀조합_저장(recipe1, recipe2);
 
                 final var author = RecipeAuthorDto.toDto(member);
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -623,8 +626,9 @@ class RecipeServiceTest extends ServiceTest {
             }
 
             @Test
-            void 전체_꿀조합_중_랭킹이_높은_상위_3개_꿀조합을_구할_수_있다() {
+            void 전체_꿀조합_중_랭킹이_높은_상위_4개_꿀조합을_구할_수_있다() {
                 // given
+                final var guestId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -636,15 +640,15 @@ class RecipeServiceTest extends ServiceTest {
                 복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
 
                 final var author = RecipeAuthorDto.toDto(member);
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author);
-                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), author);
-                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), author);
-                final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -658,6 +662,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 꿀조합_좋아요_수가_같으면_최근_생성된_꿀조합의_랭킹을_더_높게_반환한다() {
                 // given
+                final var guestId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -667,13 +672,13 @@ class RecipeServiceTest extends ServiceTest {
                 복수_꿀조합_저장(recipe1, recipe2);
 
                 final var author = RecipeAuthorDto.toDto(member);
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -683,6 +688,7 @@ class RecipeServiceTest extends ServiceTest {
             @Test
             void 꿀조합_생성_일자가_같으면_좋아요_수가_많은_꿀조합의_랭킹을_더_높게_반환한다() {
                 // given
+                final var guestId = -1L;
                 final var member = 멤버_멤버1_생성();
                 단일_멤버_저장(member);
 
@@ -692,13 +698,13 @@ class RecipeServiceTest extends ServiceTest {
                 복수_꿀조합_저장(recipe1, recipe2);
 
                 final var author = RecipeAuthorDto.toDto(member);
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
                 // when
-                final var actual = recipeService.getTop3Recipes();
+                final var actual = recipeService.getTop4Recipes(guestId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -39,6 +39,7 @@ import com.funeat.product.domain.Product;
 import com.funeat.product.exception.ProductException.ProductNotFoundException;
 import com.funeat.recipe.dto.RankingRecipeDto;
 import com.funeat.recipe.dto.RankingRecipesResponse;
+import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCommentCondition;
 import com.funeat.recipe.dto.RecipeCommentCreateRequest;
 import com.funeat.recipe.dto.RecipeCommentResponse;
@@ -586,7 +587,8 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe = 레시피_생성(member, 2L, now);
                 단일_꿀조합_저장(recipe);
 
-                final var rankingRecipeDto = RankingRecipeDto.toDto(recipe, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto = RankingRecipeDto.toDto(recipe, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = Collections.singletonList(rankingRecipeDto);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -610,8 +612,9 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 2L, now);
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -636,9 +639,10 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe3 = 레시피_생성(member, 2L, now);
                 복수_꿀조합_저장(recipe1, recipe2, recipe3);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
-                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -664,10 +668,11 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe4 = 레시피_생성(member, 6L, now);
                 복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
-                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
-                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), author, false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -697,10 +702,11 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe4 = 레시피_생성(member, 6L, now);
                 복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
-                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
-                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), author, false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -729,10 +735,11 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipeFavorite = 레시피_좋아요_생성(member, recipe1, true);
                 단일_꿀조합_좋아요_저장(recipeFavorite);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), true);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
-                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), false);
-                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, true);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
+                final var rankingRecipeDto3 = RankingRecipeDto.toDto(recipe3, Collections.emptyList(), author, false);
+                final var rankingRecipeDto4 = RankingRecipeDto.toDto(recipe4, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto4, rankingRecipeDto3, rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -760,8 +767,9 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 10L, now.minusDays(4L));
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 
@@ -785,8 +793,9 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipe2 = 레시피_생성(member, 4L, now.minusDays(1L));
                 복수_꿀조합_저장(recipe1, recipe2);
 
-                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), false);
-                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), false);
+                final var author = RecipeAuthorDto.toDto(member);
+                final var rankingRecipeDto1 = RankingRecipeDto.toDto(recipe1, Collections.emptyList(), author, false);
+                final var rankingRecipeDto2 = RankingRecipeDto.toDto(recipe2, Collections.emptyList(), author, false);
                 final var rankingRecipesDtos = List.of(rankingRecipeDto2, rankingRecipeDto1);
                 final var expected = RankingRecipesResponse.toResponse(rankingRecipesDtos);
 


### PR DESCRIPTION
## Issue

- close #37 

## ✨ 구현한 기능

- 꿀조합 랭킹 API response 수정
  - 반환 데이터 3개 -> 4개
  - `author` : 객체 -> String
  - `favoriteCount` -> `favorite`(boolean)

- 로그인 한 사용자는 `favorite`에 자신이 누른 좋아요 여부 / 로그인 안한 사용자는 `favorite` 전부 false로 반환

- 관련 서비스 테스트 수정 및 추가

## 📢 논의하고 싶은 내용

X

## 🎸 기타

- 로그인 여부에 상관없이 모두 API 접근이 가능해야 하기 때문에 해당 API 경로에 대한 인터셉터랑 전체 ArgumentResolver 로직 수정했습니다. 
  (우선은 로그인 안한 경우 게스트를 나타내는 `LoginInfo` 반환하도록 수정)

## ⏰ 일정

- 추정 시간 : 1h
- 걸린 시간 : 2h
