### PR TITLE
refactor: 꿀조합 검색 결과에 상품 이미지 및 평점 정보 추가

### DIFF
--- a/src/main/java/com/funeat/recipe/dto/DetailProductRecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/DetailProductRecipeDto.java
@@ -8,16 +8,20 @@ public class DetailProductRecipeDto {
     private final String name;
     private final Long price;
     private final String image;
+    private final Double averageRating;
 
-    private DetailProductRecipeDto(final Long id, final String name, final Long price, final String image) {
+    private DetailProductRecipeDto(final Long id, final String name, final Long price, final String image,
+                                   final Double averageRating) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.image = image;
+        this.averageRating = averageRating;
     }
 
     public static DetailProductRecipeDto toDto(final Product product) {
-        return new DetailProductRecipeDto(product.getId(), product.getName(), product.getPrice(), product.getImage());
+        return new DetailProductRecipeDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
+                product.getAverageRating());
     }
 
     public Long getId() {
@@ -34,5 +38,9 @@ public class DetailProductRecipeDto {
 
     public String getImage() {
         return image;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
     }
 }

--- a/src/main/java/com/funeat/recipe/dto/SearchRecipeResultDto.java
+++ b/src/main/java/com/funeat/recipe/dto/SearchRecipeResultDto.java
@@ -5,7 +5,6 @@ import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SearchRecipeResultDto {
 
@@ -13,12 +12,12 @@ public class SearchRecipeResultDto {
     private final String image;
     private final String title;
     private final RecipeAuthorDto author;
-    private final List<ProductRecipeDto> products;
+    private final List<DetailProductRecipeDto> products;
     private final Long favoriteCount;
     private final LocalDateTime createdAt;
 
     public SearchRecipeResultDto(final Long id, final String image, final String title, final RecipeAuthorDto author,
-                                 final List<ProductRecipeDto> products, final Long favoriteCount,
+                                 final List<DetailProductRecipeDto> products, final Long favoriteCount,
                                  final LocalDateTime createdAt) {
         this.id = id;
         this.image = image;
@@ -31,9 +30,9 @@ public class SearchRecipeResultDto {
 
     public static SearchRecipeResultDto toDto(final Recipe recipe, final List<RecipeImage> images,
                                               final List<Product> products) {
-        final List<ProductRecipeDto> productRecipes = products.stream()
-                .map(ProductRecipeDto::toDto)
-                .collect(Collectors.toList());
+        final List<DetailProductRecipeDto> productRecipes = products.stream()
+                .map(DetailProductRecipeDto::toDto)
+                .toList();
 
         if (images.isEmpty()) {
             return new SearchRecipeResultDto(recipe.getId(), null, recipe.getTitle(),
@@ -61,7 +60,7 @@ public class SearchRecipeResultDto {
         return author;
     }
 
-    public List<ProductRecipeDto> getProducts() {
+    public List<DetailProductRecipeDto> getProducts() {
         return products;
     }
 


### PR DESCRIPTION
## Issue

- close #40 

## ✨ 구현한 기능

- 꿀조합 검색 결과 API 수정
  - 상품 image 추가
  - 상품 averageRating 추가

## 📢 논의하고 싶은 내용

X

## 🎸 기타

- 꿀조합 상세 조회 API의 `DetailProductRecipeDto`랑 같은 정보를 Response로 담으면 돼서 #42 에서 수정한 `DetailProductRecipeDto` 그대로 사용하도록 수정했습니다.
  - ~기존 `ProductRecipeDto`는 #41 에서 categoryType까지 포함하도록 수정해야 함~
    (아직 디자이너랑 논의중이라고 해서 categoryType 포함 안하는 걸로 되면 dto 하나로 통합할게요)
  - 이번에 API 수정이 많아서 리팩터링 다 끝내고 전체적으로 dto 중복되는 거 정리해야 할 듯

## ⏰ 일정

- 추정 시간 : 30min
- 걸린 시간 : 30min
