### PR TITLE
refactor: 꿀조합 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/funeat/product/application/ProductService.java
+++ b/src/main/java/com/funeat/product/application/ProductService.java
@@ -35,6 +35,7 @@ import com.funeat.tag.domain.Tag;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -174,7 +175,7 @@ public class ProductService {
         return productRepository.findAllWithReviewCountByNameContaining(query, lastProductId, size);
     }
 
-    public SortingRecipesResponse getProductRecipes(final Long productId, final Pageable pageable) {
+    public SortingRecipesResponse getProductRecipes(final Long memberId, final Long productId, final Pageable pageable) {
         final Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductNotFoundException(PRODUCT_NOT_FOUND, productId));
 
@@ -182,12 +183,15 @@ public class ProductService {
 
         final PageDto pageDto = PageDto.toDto(recipes);
         final List<RecipeDto> recipeDtos = recipes.stream()
-                .map(recipe -> {
-                    final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
-                    final List<Product> products = productRecipeRepository.findProductByRecipe(recipe);
-                    return RecipeDto.toDto(recipe, images, products);
-                })
-                .collect(Collectors.toList());
+                .map(recipe -> createRecipeDto(memberId, recipe))
+                .toList();
         return SortingRecipesResponse.toResponse(pageDto, recipeDtos);
+    }
+
+    @NotNull
+    private RecipeDto createRecipeDto(final Long memberId, final Recipe recipe) {
+        final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
+        final List<Product> products = productRecipeRepository.findProductByRecipe(recipe);
+        return RecipeDto.toDto(recipe, images, products);
     }
 }

--- a/src/main/java/com/funeat/product/application/ProductService.java
+++ b/src/main/java/com/funeat/product/application/ProductService.java
@@ -1,9 +1,14 @@
 package com.funeat.product.application;
 
+import static com.funeat.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.funeat.product.exception.CategoryErrorCode.CATEGORY_NOT_FOUND;
 import static com.funeat.product.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
 
 import com.funeat.common.dto.PageDto;
+import com.funeat.member.domain.Member;
+import com.funeat.member.exception.MemberException.MemberNotFoundException;
+import com.funeat.member.persistence.MemberRepository;
+import com.funeat.member.persistence.RecipeFavoriteRepository;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.Product;
 import com.funeat.product.dto.ProductInCategoryDto;
@@ -35,7 +40,6 @@ import com.funeat.tag.domain.Tag;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -52,6 +56,7 @@ public class ProductService {
     private static final int RANKING_SIZE = 3;
     private static final int DEFAULT_PAGE_SIZE = 10;
     private static final int DEFAULT_CURSOR_PAGINATION_SIZE = 11;
+    private static final long GUEST_ID = -1L;
 
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
@@ -60,12 +65,15 @@ public class ProductService {
     private final ProductRecipeRepository productRecipeRepository;
     private final RecipeImageRepository recipeImageRepository;
     private final RecipeRepository recipeRepository;
+    private final MemberRepository memberRepository;
+    private final RecipeFavoriteRepository recipeFavoriteRepository;
 
     public ProductService(final CategoryRepository categoryRepository, final ProductRepository productRepository,
                           final ReviewTagRepository reviewTagRepository, final ReviewRepository reviewRepository,
                           final ProductRecipeRepository productRecipeRepository,
                           final RecipeImageRepository recipeImageRepository,
-                          final RecipeRepository recipeRepository) {
+                          final RecipeRepository recipeRepository, final MemberRepository memberRepository,
+                          final RecipeFavoriteRepository recipeFavoriteRepository) {
         this.categoryRepository = categoryRepository;
         this.productRepository = productRepository;
         this.reviewTagRepository = reviewTagRepository;
@@ -73,6 +81,8 @@ public class ProductService {
         this.productRecipeRepository = productRecipeRepository;
         this.recipeImageRepository = recipeImageRepository;
         this.recipeRepository = recipeRepository;
+        this.memberRepository = memberRepository;
+        this.recipeFavoriteRepository = recipeFavoriteRepository;
     }
 
     public ProductsInCategoryResponse getAllProductsInCategory(final Long categoryId, final Long lastProductId,
@@ -188,10 +198,17 @@ public class ProductService {
         return SortingRecipesResponse.toResponse(pageDto, recipeDtos);
     }
 
-    @NotNull
     private RecipeDto createRecipeDto(final Long memberId, final Recipe recipe) {
         final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
         final List<Product> products = productRecipeRepository.findProductByRecipe(recipe);
-        return RecipeDto.toDto(recipe, images, products);
+
+        if (memberId == GUEST_ID) {
+            return RecipeDto.toDto(recipe, images, products, false);
+        }
+
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
+        final Boolean favorite = recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(member, recipe);
+        return RecipeDto.toDto(recipe, images, products, favorite);
     }
 }

--- a/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -1,5 +1,7 @@
 package com.funeat.product.presentation;
 
+import com.funeat.auth.dto.LoginInfo;
+import com.funeat.auth.util.AuthenticationPrincipal;
 import com.funeat.product.application.ProductService;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.ProductSortCondition;
@@ -8,7 +10,6 @@ import com.funeat.product.dto.RankingProductsResponse;
 import com.funeat.product.dto.SearchProductResultsResponse;
 import com.funeat.product.dto.SearchProductsResponse;
 import com.funeat.recipe.dto.SortingRecipesResponse;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -64,9 +65,10 @@ public class ProductApiController implements ProductController {
     }
 
     @GetMapping("/products/{productId}/recipes")
-    public ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
+    public ResponseEntity<SortingRecipesResponse> getProductRecipes(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                                    @PathVariable final Long productId,
                                                                     @PageableDefault final Pageable pageable) {
-        final SortingRecipesResponse response = productService.getProductRecipes(productId, pageable);
+        final SortingRecipesResponse response = productService.getProductRecipes(loginInfo.getId(), productId, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -1,5 +1,7 @@
 package com.funeat.product.presentation;
 
+import com.funeat.auth.dto.LoginInfo;
+import com.funeat.auth.util.AuthenticationPrincipal;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductsResponse;
@@ -71,6 +73,7 @@ public interface ProductController {
             description = "해당 상품 꿀조합 목록 조회 성공."
     )
     @GetMapping
-    ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
+    ResponseEntity<SortingRecipesResponse> getProductRecipes(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                             @PathVariable final Long productId,
                                                              @PageableDefault final Pageable pageable);
 }

--- a/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -156,19 +156,21 @@ public class RecipeService {
         return MemberRecipesResponse.toResponse(page, dtos);
     }
 
-    public SortingRecipesResponse getSortingRecipes(final Pageable pageable) {
+    public SortingRecipesResponse getSortingRecipes(final Long memberId, final Pageable pageable) {
         final Page<Recipe> pages = recipeRepository.findAll(pageable);
 
         final PageDto page = PageDto.toDto(pages);
         final List<RecipeDto> recipes = pages.getContent().stream()
-                .map(recipe -> {
-                    final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
-                    final List<Product> products = productRecipeRepository.findProductByRecipe(recipe);
-                    return RecipeDto.toDto(recipe, images, products);
-                })
+                .map(recipe -> createRecipeDto(memberId, recipe))
                 .collect(Collectors.toList());
 
         return SortingRecipesResponse.toResponse(page, recipes);
+    }
+
+    private RecipeDto createRecipeDto(final Long memberId, final Recipe recipe) {
+        final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
+        final List<Product> products = productRecipeRepository.findProductByRecipe(recipe);
+        return RecipeDto.toDto(recipe, images, products);
     }
 
     @Transactional

--- a/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
@@ -7,15 +7,21 @@ public class ProductRecipeDto {
     private final Long id;
     private final String name;
     private final Long price;
+    private final String image;
+    private final Double averageRating;
 
-    private ProductRecipeDto(final Long id, final String name, final Long price) {
+    private ProductRecipeDto(final Long id, final String name, final Long price, final String image,
+                             final Double averageRating) {
         this.id = id;
         this.name = name;
         this.price = price;
+        this.image = image;
+        this.averageRating = averageRating;
     }
 
     public static ProductRecipeDto toDto(final Product product) {
-        return new ProductRecipeDto(product.getId(), product.getName(), product.getPrice());
+        return new ProductRecipeDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
+                product.getAverageRating());
     }
 
     public Long getId() {
@@ -28,5 +34,13 @@ public class ProductRecipeDto {
 
     public Long getPrice() {
         return price;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
     }
 }

--- a/src/main/java/com/funeat/recipe/dto/RecipeDto.java
+++ b/src/main/java/com/funeat/recipe/dto/RecipeDto.java
@@ -5,42 +5,44 @@ import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class RecipeDto {
 
     private final Long id;
     private final String image;
     private final String title;
+    private final String content;
     private final RecipeAuthorDto author;
     private final List<ProductRecipeDto> products;
-    private final Long favoriteCount;
+    private final Boolean favorite;
     private final LocalDateTime createdAt;
 
-    public RecipeDto(final Long id, final String image, final String title, final RecipeAuthorDto author,
-                     final List<ProductRecipeDto> products,
-                     final Long favoriteCount, final LocalDateTime createdAt) {
+    public RecipeDto(final Long id, final String image, final String title, final String content,
+                     final RecipeAuthorDto author, final List<ProductRecipeDto> products, final Boolean favorite,
+                     final LocalDateTime createdAt) {
         this.id = id;
         this.image = image;
         this.title = title;
+        this.content = content;
         this.author = author;
         this.products = products;
-        this.favoriteCount = favoriteCount;
+        this.favorite = favorite;
         this.createdAt = createdAt;
     }
 
     public static RecipeDto toDto(final Recipe recipe, final List<RecipeImage> recipeImages,
-                                  final List<Product> products) {
+                                  final List<Product> products, final Boolean favorite) {
         final RecipeAuthorDto authorDto = RecipeAuthorDto.toDto(recipe.getMember());
         final List<ProductRecipeDto> productDtos = products.stream()
                 .map(ProductRecipeDto::toDto)
-                .collect(Collectors.toList());
+                .toList();
+
         if (recipeImages.isEmpty()) {
-            return new RecipeDto(recipe.getId(), null, recipe.getTitle(), authorDto, productDtos,
-                    recipe.getFavoriteCount(), recipe.getCreatedAt());
+            return new RecipeDto(recipe.getId(), null, recipe.getTitle(), recipe.getContent(), authorDto,
+                    productDtos, favorite, recipe.getCreatedAt());
         }
-        return new RecipeDto(recipe.getId(), recipeImages.get(0).getImage(), recipe.getTitle(), authorDto, productDtos,
-                recipe.getFavoriteCount(), recipe.getCreatedAt());
+        return new RecipeDto(recipe.getId(), recipeImages.get(0).getImage(), recipe.getTitle(), recipe.getContent(),
+                authorDto, productDtos, favorite, recipe.getCreatedAt());
     }
 
     public Long getId() {
@@ -55,6 +57,10 @@ public class RecipeDto {
         return title;
     }
 
+    public String getContent() {
+        return content;
+    }
+
     public RecipeAuthorDto getAuthor() {
         return author;
     }
@@ -63,8 +69,8 @@ public class RecipeDto {
         return products;
     }
 
-    public Long getFavoriteCount() {
-        return favoriteCount;
+    public Boolean getFavorite() {
+        return favorite;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -60,8 +60,9 @@ public class RecipeApiController implements RecipeController {
     }
 
     @GetMapping(value = "/api/recipes")
-    public ResponseEntity<SortingRecipesResponse> getSortingRecipes(@PageableDefault final Pageable pageable) {
-        final SortingRecipesResponse response = recipeService.getSortingRecipes(pageable);
+    public ResponseEntity<SortingRecipesResponse> getSortingRecipes(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                                    @PageableDefault final Pageable pageable) {
+        final SortingRecipesResponse response = recipeService.getSortingRecipes(loginInfo.getId(), pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/funeat/recipe/presentation/RecipeController.java
+++ b/src/main/java/com/funeat/recipe/presentation/RecipeController.java
@@ -56,7 +56,8 @@ public interface RecipeController {
             description = "꿀조합 목록 조회 성공."
     )
     @GetMapping
-    ResponseEntity<SortingRecipesResponse> getSortingRecipes(@PageableDefault final Pageable pageable);
+    ResponseEntity<SortingRecipesResponse> getSortingRecipes(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                             @PageableDefault final Pageable pageable);
 
     @Operation(summary = "꿀조합 좋아요", description = "꿀조합에 좋아요 또는 취소를 한다.")
     @ApiResponse(

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -54,6 +54,17 @@ public class RecipeSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 레시피_목록_요청(final String loginCookie, final String sort, final Long page) {
+        return given()
+                .queryParam("sort", sort)
+                .queryParam("page", page)
+                .cookie("SESSION", loginCookie)
+                .when()
+                .get("/api/recipes")
+                .then()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 레시피_좋아요_요청(final String loginCookie, final Long recipeId,
                                                            final RecipeFavoriteRequest request) {
         return given()

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -275,159 +275,277 @@ class RecipeServiceTest extends ServiceTest {
     @Nested
     class getSortingRecipes_성공_테스트 {
 
-        @Test
-        void 꿀조합을_좋아요가_많은_순으로_정렬할_수_있다() {
-            // given
-            final var loginId = -1L;
-            final var member1 = 멤버_멤버1_생성();
-            final var member2 = 멤버_멤버2_생성();
-            final var member3 = 멤버_멤버3_생성();
-            복수_멤버_저장(member1, member2, member3);
+        @Nested
+        class 정렬_기준에_따른_테스트 {
 
-            final var category = 카테고리_간편식사_생성();
-            단일_카테고리_저장(category);
+            @Test
+            void 꿀조합을_좋아요가_많은_순으로_정렬할_수_있다() {
+                // given
+                final var loginId = -1L;
+                final var member1 = 멤버_멤버1_생성();
+                final var member2 = 멤버_멤버2_생성();
+                final var member3 = 멤버_멤버3_생성();
+                복수_멤버_저장(member1, member2, member3);
 
-            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
-            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
-            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
-            복수_상품_저장(product1, product2, product3);
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
 
-            final var recipe1_1 = 레시피_생성(member1, 1L);
-            final var recipe1_2 = 레시피_생성(member1, 3L);
-            final var recipe1_3 = 레시피_생성(member1, 2L);
-            복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
+                final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+                final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+                final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+                복수_상품_저장(product1, product2, product3);
 
-            final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
-            final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
-            final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
-            final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
-            final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
-            복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
-                    product_recipe_1_2_2);
+                final var recipe1_1 = 레시피_생성(member1, 1L);
+                final var recipe1_2 = 레시피_생성(member1, 3L);
+                final var recipe1_3 = 레시피_생성(member1, 2L);
+                복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
 
-            final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
-            final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
-            final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
-            복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
+                final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
+                final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
+                final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
+                final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
+                final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
+                복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
+                        product_recipe_1_2_2);
 
-            final var page = 페이지요청_생성(0, 10, 좋아요수_내림차순);
+                final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
+                final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
+                final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
+                복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
 
-            // when
-            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
-            final var expected = List.of(
-                    RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3), false),
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false));
+                final var page = 페이지요청_생성(0, 10, 좋아요수_내림차순);
 
-            // then
-            assertThat(actual)
-                    .usingRecursiveComparison()
-                    .isEqualTo(expected);
+                // when
+                final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
+                final var expected = List.of(
+                        RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
+                                List.of(product1, product3), false),
+                        RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
+                        RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3),
+                                false));
+
+                // then
+                assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+
+            @Test
+            void 꿀조합을_최신순으로_정렬할_수_있다() throws InterruptedException {
+                // given
+                final var loginId = -1L;
+                final var member1 = 멤버_멤버1_생성();
+                final var member2 = 멤버_멤버2_생성();
+                final var member3 = 멤버_멤버3_생성();
+                복수_멤버_저장(member1, member2, member3);
+
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
+
+                final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+                final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+                final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+                복수_상품_저장(product1, product2, product3);
+
+                final var recipe1_1 = 레시피_생성(member1, 1L);
+                Thread.sleep(100);
+                final var recipe1_2 = 레시피_생성(member1, 3L);
+                Thread.sleep(100);
+                final var recipe1_3 = 레시피_생성(member1, 2L);
+                복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
+
+                final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
+                final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
+                final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
+                final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
+                final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
+                복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
+                        product_recipe_1_2_2);
+
+                final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
+                final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
+                final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
+                복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
+
+                final var page = 페이지요청_생성(0, 10, 최신순);
+
+                // when
+                final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
+                final var expected = List.of(
+                        RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
+                        RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
+                                List.of(product1, product3), false),
+                        RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3),
+                                false));
+
+                // then
+                assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+
+            @Test
+            void 꿀조합을_오래된순으로_정렬할_수_있다() {
+                // given
+                final var loginId = -1L;
+                final var member1 = 멤버_멤버1_생성();
+                final var member2 = 멤버_멤버2_생성();
+                final var member3 = 멤버_멤버3_생성();
+                복수_멤버_저장(member1, member2, member3);
+
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
+
+                final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+                final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+                final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+                복수_상품_저장(product1, product2, product3);
+
+                final var recipe1_1 = 레시피_생성(member1, 1L);
+                final var recipe1_2 = 레시피_생성(member1, 3L);
+                final var recipe1_3 = 레시피_생성(member1, 2L);
+                복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
+
+                final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
+                final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
+                final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
+                final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
+                final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
+                복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
+                        product_recipe_1_2_2);
+
+                final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
+                final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
+                final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
+                복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
+
+                final var page = 페이지요청_생성(0, 10, 과거순);
+
+                // when
+                final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
+                final var expected = List.of(
+                        RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3),
+                                false),
+                        RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
+                                List.of(product1, product3), false),
+                        RecipeDto.toDto(recipe1_3, List.of(), List.of(), false));
+
+                // then
+                assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
         }
 
-        @Test
-        void 꿀조합을_최신순으로_정렬할_수_있다() throws InterruptedException {
-            // given
-            final var loginId = -1L;
-            final var member1 = 멤버_멤버1_생성();
-            final var member2 = 멤버_멤버2_생성();
-            final var member3 = 멤버_멤버3_생성();
-            복수_멤버_저장(member1, member2, member3);
+        @Nested
+        class 로그인_여부_응답_테스트 {
 
-            final var category = 카테고리_간편식사_생성();
-            단일_카테고리_저장(category);
+            @Test
+            void 로그인_안한_경우_모든_꿀조합의_좋아요는_false로_반환한다() {
+                // given
+                final var loginId = -1L;
+                final var member1 = 멤버_멤버1_생성();
+                final var member2 = 멤버_멤버2_생성();
+                final var member3 = 멤버_멤버3_생성();
+                복수_멤버_저장(member1, member2, member3);
 
-            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
-            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
-            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
-            복수_상품_저장(product1, product2, product3);
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
 
-            final var recipe1_1 = 레시피_생성(member1, 1L);
-            Thread.sleep(100);
-            final var recipe1_2 = 레시피_생성(member1, 3L);
-            Thread.sleep(100);
-            final var recipe1_3 = 레시피_생성(member1, 2L);
-            복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
+                final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+                final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+                final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+                복수_상품_저장(product1, product2, product3);
 
-            final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
-            final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
-            final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
-            final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
-            final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
-            복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
-                    product_recipe_1_2_2);
+                final var recipe1_1 = 레시피_생성(member1, 1L);
+                final var recipe1_2 = 레시피_생성(member1, 3L);
+                final var recipe1_3 = 레시피_생성(member1, 2L);
+                복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
 
-            final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
-            final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
-            final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
-            복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
+                final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
+                final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
+                final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
+                final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
+                final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
+                복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
+                        product_recipe_1_2_2);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+                final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
+                final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
+                final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
+                복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
 
-            // when
-            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
-            final var expected = List.of(
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
-                    RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3), false),
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false));
+                final var page = 페이지요청_생성(0, 10, 좋아요수_내림차순);
 
-            // then
-            assertThat(actual)
-                    .usingRecursiveComparison()
-                    .isEqualTo(expected);
-        }
+                // when
+                final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
+                final var expected = List.of(
+                        RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
+                                List.of(product1, product3), false),
+                        RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
+                        RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3),
+                                false));
 
-        @Test
-        void 꿀조합을_오래된순으로_정렬할_수_있다() {
-            // given
-            final var loginId = -1L;
-            final var member1 = 멤버_멤버1_생성();
-            final var member2 = 멤버_멤버2_생성();
-            final var member3 = 멤버_멤버3_생성();
-            복수_멤버_저장(member1, member2, member3);
+                // then
+                assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
 
-            final var category = 카테고리_간편식사_생성();
-            단일_카테고리_저장(category);
+            @Test
+            void 로그인_한_경우_각_꿀조합의_좋아요는_로그인_사용자의_좋아요_여부로_반환한다() {
+                // given
+                final var member1 = 멤버_멤버1_생성();
+                final var member2 = 멤버_멤버2_생성();
+                final var member3 = 멤버_멤버3_생성();
+                복수_멤버_저장(member1, member2, member3);
+                final var loginId = member1.getId();
 
-            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
-            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
-            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
-            복수_상품_저장(product1, product2, product3);
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
 
-            final var recipe1_1 = 레시피_생성(member1, 1L);
-            final var recipe1_2 = 레시피_생성(member1, 3L);
-            final var recipe1_3 = 레시피_생성(member1, 2L);
-            복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
+                final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+                final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+                final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+                복수_상품_저장(product1, product2, product3);
 
-            final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
-            final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
-            final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
-            final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
-            final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
-            복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
-                    product_recipe_1_2_2);
+                final var recipe1_1 = 레시피_생성(member1, 1L);
+                final var recipe1_2 = 레시피_생성(member1, 3L);
+                final var recipe1_3 = 레시피_생성(member1, 2L);
+                복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
 
-            final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
-            final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
-            final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
-            복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
+                final var product_recipe_1_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_1);
+                final var product_recipe_1_1_2 = 레시피_안에_들어가는_상품_생성(product2, recipe1_1);
+                final var product_recipe_1_1_3 = 레시피_안에_들어가는_상품_생성(product3, recipe1_1);
+                final var product_recipe_1_2_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1_2);
+                final var product_recipe_1_2_2 = 레시피_안에_들어가는_상품_생성(product3, recipe1_2);
+                복수_꿀조합_상품_저장(product_recipe_1_1_1, product_recipe_1_1_2, product_recipe_1_1_3, product_recipe_1_2_1,
+                        product_recipe_1_2_2);
 
-            final var page = 페이지요청_생성(0, 10, 과거순);
+                final var recipeImage1_1_1 = 레시피이미지_생성(recipe1_1);
+                final var recipeImage1_2_1 = 레시피이미지_생성(recipe1_2);
+                final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
+                복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
 
-            // when
-            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
-            final var expected = List.of(
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false),
-                    RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3), false),
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false));
+                final var recipeFavorite = 레시피_좋아요_생성(member1, recipe1_1, true);
+                단일_꿀조합_좋아요_저장(recipeFavorite);
 
-            // then
-            assertThat(actual)
-                    .usingRecursiveComparison()
-                    .isEqualTo(expected);
+                final var page = 페이지요청_생성(0, 10, 좋아요수_내림차순);
+
+                // when
+                final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
+                final var expected = List.of(
+                        RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
+                                List.of(product1, product3), false),
+                        RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
+                        RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3),
+                                true));
+
+                // then
+                assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
         }
     }
 

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -316,9 +316,9 @@ class RecipeServiceTest extends ServiceTest {
             final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3)),
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of()),
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3)));
+                            List.of(product1, product3), false),
+                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
+                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false));
 
             // then
             assertThat(actual)
@@ -368,10 +368,10 @@ class RecipeServiceTest extends ServiceTest {
             // when
             final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of()),
+                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false),
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3)),
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3)));
+                            List.of(product1, product3), false),
+                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false));
 
             // then
             assertThat(actual)
@@ -419,10 +419,10 @@ class RecipeServiceTest extends ServiceTest {
             // when
             final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
-                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3)),
+                    RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3), false),
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
-                            List.of(product1, product3)),
-                    RecipeDto.toDto(recipe1_3, List.of(), List.of()));
+                            List.of(product1, product3), false),
+                    RecipeDto.toDto(recipe1_3, List.of(), List.of(), false));
 
             // then
             assertThat(actual)

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -278,6 +278,7 @@ class RecipeServiceTest extends ServiceTest {
         @Test
         void 꿀조합을_좋아요가_많은_순으로_정렬할_수_있다() {
             // given
+            final var loginId = -1L;
             final var member1 = 멤버_멤버1_생성();
             final var member2 = 멤버_멤버2_생성();
             final var member3 = 멤버_멤버3_생성();
@@ -312,7 +313,7 @@ class RecipeServiceTest extends ServiceTest {
             final var page = 페이지요청_생성(0, 10, 좋아요수_내림차순);
 
             // when
-            final var actual = recipeService.getSortingRecipes(page).getRecipes();
+            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
                             List.of(product1, product3)),
@@ -328,6 +329,7 @@ class RecipeServiceTest extends ServiceTest {
         @Test
         void 꿀조합을_최신순으로_정렬할_수_있다() throws InterruptedException {
             // given
+            final var loginId = -1L;
             final var member1 = 멤버_멤버1_생성();
             final var member2 = 멤버_멤버2_생성();
             final var member3 = 멤버_멤버3_생성();
@@ -364,7 +366,7 @@ class RecipeServiceTest extends ServiceTest {
             final var page = 페이지요청_생성(0, 10, 최신순);
 
             // when
-            final var actual = recipeService.getSortingRecipes(page).getRecipes();
+            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
                     RecipeDto.toDto(recipe1_3, List.of(), List.of()),
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),
@@ -380,6 +382,7 @@ class RecipeServiceTest extends ServiceTest {
         @Test
         void 꿀조합을_오래된순으로_정렬할_수_있다() {
             // given
+            final var loginId = -1L;
             final var member1 = 멤버_멤버1_생성();
             final var member2 = 멤버_멤버2_생성();
             final var member3 = 멤버_멤버3_생성();
@@ -414,7 +417,7 @@ class RecipeServiceTest extends ServiceTest {
             final var page = 페이지요청_생성(0, 10, 과거순);
 
             // when
-            final var actual = recipeService.getSortingRecipes(page).getRecipes();
+            final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
             final var expected = List.of(
                     RecipeDto.toDto(recipe1_1, List.of(recipeImage1_1_1), List.of(product1, product2, product3)),
                     RecipeDto.toDto(recipe1_2, List.of(recipeImage1_2_1, recipeImage1_2_2),


### PR DESCRIPTION
## Issue

- close #41 

## ✨ 구현한 기능

- 꿀조합 목록 조회 API 수정
  - `favoriteCount` -> `favorite`(boolean)
  - `content` 추가
  - 상품 `image` 추가
  - 상품 `averageRating` 추가

## 📢 논의하고 싶은 내용

- 상품이 포함된 꿀조합 목록을 조회하는 API에서도 같은 DTO를 사용하고 있고, 디자인 시안에서도 같은 방식으로 사용되는 것 같아서 일단 같이 수정했습니다.
  근데 보면 볼수록 얘는 product보다는 recipe에 있어야 될 것 같은데, 지금 도메인 전체적으로 수정하고 있다고 해서 일단 인지만 해두고 도메인 수정할 때 같이 수정하도록 할까요?

## 🎸 기타

X

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 2h
