### PR TITLE
refactor: 마이페이지에 작성한 꿀조합 정보 조회 변경

### DIFF
--- a/src/main/java/com/funeat/member/dto/MemberRecipeDto.java
+++ b/src/main/java/com/funeat/member/dto/MemberRecipeDto.java
@@ -11,36 +11,35 @@ public class MemberRecipeDto {
     private final Long id;
     private final String title;
     private final String content;
+    private final MemberProfileResponse author;
     private final LocalDateTime createdAt;
     private final String image;
-    private final Long favoriteCount;
-    private final List<MemberRecipeProductDto> products;
 
-    private MemberRecipeDto(final Long id, final String title, final String content, final LocalDateTime createdAt,
-                            final Long favoriteCount, final List<MemberRecipeProductDto> products) {
-        this(id, title, content, createdAt, null, favoriteCount, products);
+    private MemberRecipeDto(final Long id, final String title, final String content, final MemberProfileResponse author,
+                            final LocalDateTime createdAt) {
+        this(id, title, content, author, createdAt, null);
     }
 
     @JsonCreator
-    private MemberRecipeDto(final Long id, final String title, final String content, final LocalDateTime createdAt,
-                            final String image, final Long favoriteCount, final List<MemberRecipeProductDto> products) {
+    private MemberRecipeDto(final Long id, final String title, final String content, final MemberProfileResponse author,
+                            final LocalDateTime createdAt, final String image) {
         this.id = id;
         this.title = title;
         this.content = content;
+        this.author = author;
         this.createdAt = createdAt;
         this.image = image;
-        this.favoriteCount = favoriteCount;
-        this.products = products;
     }
 
-    public static MemberRecipeDto toDto(final Recipe recipe, final List<RecipeImage> findRecipeImages,
-                                        final List<MemberRecipeProductDto> memberRecipeProductDtos) {
+    public static MemberRecipeDto toDto(final Recipe recipe, final List<RecipeImage> findRecipeImages) {
+        final MemberProfileResponse author = MemberProfileResponse.toResponse(recipe.getMember());
+
         if (findRecipeImages.isEmpty()) {
-            return new MemberRecipeDto(recipe.getId(), recipe.getTitle(), recipe.getContent(), recipe.getCreatedAt(),
-                    recipe.getFavoriteCount(), memberRecipeProductDtos);
+            return new MemberRecipeDto(recipe.getId(), recipe.getTitle(), recipe.getContent(),author,
+                    recipe.getCreatedAt());
         }
-        return new MemberRecipeDto(recipe.getId(), recipe.getTitle(), recipe.getContent(), recipe.getCreatedAt(),
-                findRecipeImages.get(0).getImage(), recipe.getFavoriteCount(), memberRecipeProductDtos);
+        return new MemberRecipeDto(recipe.getId(), recipe.getTitle(), recipe.getContent(), author,
+                recipe.getCreatedAt(), findRecipeImages.get(0).getImage());
     }
 
     public Long getId() {
@@ -55,19 +54,15 @@ public class MemberRecipeDto {
         return content;
     }
 
+    public MemberProfileResponse getAuthor() {
+        return author;
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
     public String getImage() {
         return image;
-    }
-
-    public Long getFavoriteCount() {
-        return favoriteCount;
-    }
-
-    public List<MemberRecipeProductDto> getProducts() {
-        return products;
     }
 }

--- a/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -13,7 +13,6 @@ import com.funeat.common.dto.PageDto;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.member.dto.MemberRecipeDto;
-import com.funeat.member.dto.MemberRecipeProductDto;
 import com.funeat.member.dto.MemberRecipesResponse;
 import com.funeat.member.exception.MemberException.MemberDuplicateFavoriteException;
 import com.funeat.member.exception.MemberException.MemberNotFoundException;
@@ -143,15 +142,8 @@ public class RecipeService {
 
         final PageDto page = PageDto.toDto(sortedRecipePages);
         final List<MemberRecipeDto> dtos = sortedRecipePages.stream()
-                .map(recipe -> {
-                    final List<RecipeImage> findRecipeImages = recipeImageRepository.findByRecipe(recipe);
-                    final List<Product> productsByRecipe = productRecipeRepository.findProductByRecipe(recipe);
-                    final List<MemberRecipeProductDto> memberRecipeProductDtos = productsByRecipe.stream()
-                            .map(MemberRecipeProductDto::toDto)
-                            .collect(Collectors.toList());
-                    return MemberRecipeDto.toDto(recipe, findRecipeImages, memberRecipeProductDtos);
-                })
-                .collect(Collectors.toList());
+                .map(recipe -> MemberRecipeDto.toDto(recipe, recipeImageRepository.findByRecipe(recipe)))
+                .toList();
 
         return MemberRecipesResponse.toResponse(page, dtos);
     }

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -224,15 +224,8 @@ class RecipeServiceTest extends ServiceTest {
             // then
             final var expectedRecipes = List.of(recipe1_2, recipe1_1);
             final var expectedRecipesDtos = expectedRecipes.stream()
-                    .map(recipe -> {
-                        final var findRecipeImages = recipeImageRepository.findByRecipe(recipe);
-                        final var productsByRecipe = productRecipeRepository.findProductByRecipe(recipe);
-                        final var memberRecipeProductDtos = productsByRecipe.stream()
-                                .map(MemberRecipeProductDto::toDto)
-                                .collect(Collectors.toList());
-                        return MemberRecipeDto.toDto(recipe, findRecipeImages, memberRecipeProductDtos);
-                    })
-                    .collect(Collectors.toList());
+                    .map(recipe -> MemberRecipeDto.toDto(recipe, recipeImageRepository.findByRecipe(recipe)))
+                    .toList();
             final var expectedPage = new PageDto(2L, 1L, true, true, 0L, 10L);
 
             해당멤버의_꿀조합과_페이징_결과를_검증한다(actual, expectedRecipesDtos, expectedPage);

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -30,7 +30,6 @@ import com.funeat.common.ServiceTest;
 import com.funeat.common.dto.PageDto;
 import com.funeat.member.domain.Member;
 import com.funeat.member.dto.MemberRecipeDto;
-import com.funeat.member.dto.MemberRecipeProductDto;
 import com.funeat.member.dto.MemberRecipesResponse;
 import com.funeat.member.exception.MemberException.MemberNotFoundException;
 import com.funeat.product.domain.Category;


### PR DESCRIPTION
## Issue

- close #56

## ✨ 구현한 기능

![스크린샷 2024-05-22 오전 10 33 35](https://github.com/fun-eat/funeat-server/assets/79046106/d12f68e9-fcf0-4185-8067-3d214aec2bbf)

- 좋아요 개수를 삭제합니다. (사유: 더이상 사용되지 않음)
- 꿀조합에 사용된 상품 정보를 삭제합니다. (사유: 더이상 사용되지 않음)
- 유저 정보를 추가합니다. (닉네임, 프로필 사진)

## 📢 논의하고 싶은 내용

## 🎸 기타

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 30분
