### PR TITLE
refactor: 마이페이지에 작성한 리뷰 정보 조회 변경

### DIFF
--- a/src/main/java/com/funeat/member/dto/MemberReviewDto.java
+++ b/src/main/java/com/funeat/member/dto/MemberReviewDto.java
@@ -1,38 +1,50 @@
 package com.funeat.member.dto;
 
 import com.funeat.review.domain.Review;
+import com.funeat.tag.domain.Tag;
+import com.funeat.tag.dto.TagDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberReviewDto {
 
     private final Long reviewId;
     private final Long productId;
-    private final String categoryType;
     private final String productName;
     private final String content;
     private final Long rating;
-    private final Long favoriteCount;
+    private final List<TagDto> tags;
+    private final String image;
+    private final LocalDateTime createdAt;
 
-    private MemberReviewDto(final Long reviewId, final Long productId, final String categoryType,
-                            final String productName, final String content,
-                            final Long rating, final Long favoriteCount) {
+    private MemberReviewDto(final Long reviewId, final Long productId, final String productName,
+                            final String content, final Long rating, final List<TagDto> tags, final String image,
+                            final LocalDateTime createdAt) {
         this.reviewId = reviewId;
         this.productId = productId;
-        this.categoryType = categoryType;
         this.productName = productName;
         this.content = content;
         this.rating = rating;
-        this.favoriteCount = favoriteCount;
+        this.tags = tags;
+        this.image = image;
+        this.createdAt = createdAt;
     }
 
-    public static MemberReviewDto toDto(final Review review) {
+    public static MemberReviewDto toDto(final Review review, final List<Tag> tags) {
+        final List<TagDto> tagDtos = tags.stream()
+                .map(TagDto::toDto)
+                .toList();
+
         return new MemberReviewDto(
                 review.getId(),
                 review.getProduct().getId(),
-                review.getProduct().getCategory().getType().getName(),
                 review.getProduct().getName(),
                 review.getContent(),
                 review.getRating(),
-                review.getFavoriteCount()
+                tagDtos,
+                review.getImage(),
+                review.getCreatedAt()
         );
     }
 
@@ -56,11 +68,15 @@ public class MemberReviewDto {
         return rating;
     }
 
-    public Long getFavoriteCount() {
-        return favoriteCount;
+    public List<TagDto> getTags() {
+        return tags;
     }
 
-    public String getCategoryType() {
-        return categoryType;
+    public String getImage() {
+        return image;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/src/main/java/com/funeat/review/application/ReviewService.java
@@ -231,10 +231,16 @@ public class ReviewService {
         final PageDto pageDto = PageDto.toDto(sortedReviewPages);
 
         final List<MemberReviewDto> dtos = sortedReviewPages.stream()
-                .map(MemberReviewDto::toDto)
-                .collect(Collectors.toList());
+                .map(this::transformMemberReviewDtoWithReviewAndTag)
+                .toList();
 
         return MemberReviewsResponse.toResponse(pageDto, dtos);
+    }
+
+    private MemberReviewDto transformMemberReviewDtoWithReviewAndTag(final Review review) {
+        final List<Tag> tags = tagRepository.findTagsByReviewId(review.getId());
+
+        return MemberReviewDto.toDto(review, tags);
     }
 
     @Transactional

--- a/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -680,8 +680,8 @@ class ReviewServiceTest extends ServiceTest {
             // then
             final var expectedReviews = List.of(review3_1, review2_1, review1_1);
             final var expectedReviewDtos = expectedReviews.stream()
-                    .map(MemberReviewDto::toDto)
-                    .collect(Collectors.toList());
+                    .map(review -> MemberReviewDto.toDto(review, Collections.emptyList()))
+                    .toList();
             final var expectedPage = new PageDto(3L, 1L, true, true, 0L, 10L);
 
             assertThat(result.getReviews()).usingRecursiveComparison()


### PR DESCRIPTION
## Issue

- close #58

## ✨ 구현한 기능

![image](https://github.com/fun-eat/funeat-server/assets/79046106/e2e87d4c-eb74-459e-82a0-8456aebcc1f7)

[삭제] 좋아요 개수 (사유: 사용하지 않음)
[삭제] 리뷰한 상품의 종류
[추가] 태그 (맛있어요, 건강해요, ...)
[추가] 리뷰 이미지 경로
[추가] 작성일

## 📢 논의하고 싶은 내용

- @xodms0309 노션 API 문서 `마이페이지 리뷰 조회`에 `categoryType`도 삭제되었던데, 이것도 삭제하는거 맞죠??
새로운 response json에 `categoryType`이 없길래 일단 삭제처리 했습니다

## 🎸 기타

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 40분 ~ 1시간
