### PR TITLE
fix: 유저 정보 메인 DTO와 꿀조합으로 보이는 유저 정보 DTO 분리

### DIFF
--- a/src/main/java/com/funeat/member/dto/MemberRecipeDto.java
+++ b/src/main/java/com/funeat/member/dto/MemberRecipeDto.java
@@ -11,17 +11,17 @@ public class MemberRecipeDto {
     private final Long id;
     private final String title;
     private final String content;
-    private final MemberProfileResponse author;
+    private final MemberResponse author;
     private final LocalDateTime createdAt;
     private final String image;
 
-    private MemberRecipeDto(final Long id, final String title, final String content, final MemberProfileResponse author,
+    private MemberRecipeDto(final Long id, final String title, final String content, final MemberResponse author,
                             final LocalDateTime createdAt) {
         this(id, title, content, author, createdAt, null);
     }
 
     @JsonCreator
-    private MemberRecipeDto(final Long id, final String title, final String content, final MemberProfileResponse author,
+    private MemberRecipeDto(final Long id, final String title, final String content, final MemberResponse author,
                             final LocalDateTime createdAt, final String image) {
         this.id = id;
         this.title = title;
@@ -32,7 +32,7 @@ public class MemberRecipeDto {
     }
 
     public static MemberRecipeDto toDto(final Recipe recipe, final List<RecipeImage> findRecipeImages) {
-        final MemberProfileResponse author = MemberProfileResponse.toResponse(recipe.getMember());
+        final MemberResponse author = MemberResponse.toResponse(recipe.getMember());
 
         if (findRecipeImages.isEmpty()) {
             return new MemberRecipeDto(recipe.getId(), recipe.getTitle(), recipe.getContent(),author,
@@ -54,7 +54,7 @@ public class MemberRecipeDto {
         return content;
     }
 
-    public MemberProfileResponse getAuthor() {
+    public MemberResponse getAuthor() {
         return author;
     }
 

--- a/src/main/java/com/funeat/member/dto/MemberResponse.java
+++ b/src/main/java/com/funeat/member/dto/MemberResponse.java
@@ -1,0 +1,26 @@
+package com.funeat.member.dto;
+
+import com.funeat.member.domain.Member;
+
+public class MemberResponse {
+
+    private final String nickname;
+    private final String profileImage;
+
+    public MemberResponse(final String nickname, final String profileImage) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    public static MemberResponse toResponse(final Member member) {
+        return new MemberResponse(member.getNickname(), member.getProfileImage());
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+}


### PR DESCRIPTION
## Issue

- close #62 

## ✨ 구현한 기능

- 유저 정보 메인 DTO와 꿀조합으로 보이는 유저 정보 DTO 분리하지 않아서 발생하는 컴파일 에러를 수정합니다.
- 당시에 컴파일 문제도 없었고, 테스트 코드도 왜 전부 잘 돌아갔던건지 모르겠어요

## 📢 논의하고 싶은 내용

## 🎸 기타

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 5분
