### PR TITLE
refactor: 리뷰 랭킹 조회 API 수정

### DIFF
--- a/src/main/java/com/funeat/member/persistence/ReviewFavoriteRepository.java
+++ b/src/main/java/com/funeat/member/persistence/ReviewFavoriteRepository.java
@@ -14,4 +14,6 @@ public interface ReviewFavoriteRepository extends JpaRepository<ReviewFavorite, 
     void deleteByReview(final Review review);
 
     List<ReviewFavorite> findByReview(final Review review);
+
+    boolean existsByMemberAndReviewAndFavoriteTrue(final Member member, final Review review);
 }

--- a/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/src/main/java/com/funeat/review/application/ReviewService.java
@@ -63,6 +63,7 @@ public class ReviewService {
     private static final int RANKING_SIZE = 2;
     private static final long RANKING_MINIMUM_FAVORITE_COUNT = 1L;
     private static final int REVIEW_PAGE_SIZE = 10;
+    private static final long GUEST_ID = -1L;
 
     private final ReviewRepository reviewRepository;
     private final TagRepository tagRepository;
@@ -212,15 +213,25 @@ public class ReviewService {
         return sortingReviews.size() > REVIEW_PAGE_SIZE;
     }
 
-    public RankingReviewsResponse getTopReviews() {
+    public RankingReviewsResponse getTopReviews(final Long memberId) {
         final List<Review> reviews = reviewRepository.findReviewsByFavoriteCountGreaterThanEqual(RANKING_MINIMUM_FAVORITE_COUNT);
         final List<RankingReviewDto> dtos = reviews.stream()
                 .sorted(Comparator.comparing(Review::calculateRankingScore).reversed())
                 .limit(RANKING_SIZE)
-                .map(RankingReviewDto::toDto)
-                .collect(Collectors.toList());
-
+                .map(review -> createRankingReviewDto(memberId, review))
+                .toList();
         return RankingReviewsResponse.toResponse(dtos);
+    }
+
+    private RankingReviewDto createRankingReviewDto(final Long memberId, final Review review) {
+        if (memberId == GUEST_ID) {
+            return RankingReviewDto.toDto(review, false);
+        }
+
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
+        final Boolean favorite = reviewFavoriteRepository.existsByMemberAndReviewAndFavoriteTrue(member, review);
+        return RankingReviewDto.toDto(review, favorite);
     }
 
     public MemberReviewsResponse findReviewByMember(final Long memberId, final Pageable pageable) {

--- a/src/main/java/com/funeat/review/dto/RankingReviewDto.java
+++ b/src/main/java/com/funeat/review/dto/RankingReviewDto.java
@@ -7,27 +7,38 @@ import java.util.List;
 
 public class RankingReviewDto {
 
-    private final Long reviewId;
+    private final Long id;
+    private final String userName;
+    private final String profileImage;
     private final Long productId;
-    private final String categoryType;
     private final String productName;
     private final String content;
     private final String image;
+    private final Long rating;
+    private final boolean rebuy;
+    private final Long favoriteCount;
+    private final boolean favorite;
     private final List<TagDto> tags;
 
-    private RankingReviewDto(final Long reviewId, final Long productId, final String categoryType,
+    private RankingReviewDto(final Long id, final String userName, final String profileImage, final Long productId,
                              final String productName, final String content, final String image,
+                             final Long rating, final boolean rebuy, final Long favoriteCount, final boolean favorite,
                              final List<TagDto> tags) {
-        this.reviewId = reviewId;
+        this.id = id;
+        this.userName = userName;
+        this.profileImage = profileImage;
         this.productId = productId;
-        this.categoryType = categoryType;
         this.productName = productName;
         this.content = content;
         this.image = image;
+        this.rating = rating;
+        this.rebuy = rebuy;
+        this.favoriteCount = favoriteCount;
+        this.favorite = favorite;
         this.tags = tags;
     }
 
-    public static RankingReviewDto toDto(final Review review) {
+    public static RankingReviewDto toDto(final Review review, final Boolean favorite) {
         final List<TagDto> tagDtos = review.getReviewTags().stream()
                 .map(ReviewTag::getTag)
                 .map(TagDto::toDto)
@@ -35,17 +46,30 @@ public class RankingReviewDto {
 
         return new RankingReviewDto(
                 review.getId(),
+                review.getMember().getNickname(),
+                review.getMember().getProfileImage(),
                 review.getProduct().getId(),
-                review.getProduct().getCategory().getType().getName(),
                 review.getProduct().getName(),
                 review.getContent(),
                 review.getImage(),
+                review.getRating(),
+                review.getReBuy(),
+                review.getFavoriteCount(),
+                favorite,
                 tagDtos
         );
     }
 
-    public Long getReviewId() {
-        return reviewId;
+    public Long getId() {
+        return id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
     }
 
     public Long getProductId() {
@@ -60,12 +84,24 @@ public class RankingReviewDto {
         return content;
     }
 
-    public String getCategoryType() {
-        return categoryType;
-    }
-
     public String getImage() {
         return image;
+    }
+
+    public Long getRating() {
+        return rating;
+    }
+
+    public boolean isRebuy() {
+        return rebuy;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
+    }
+
+    public boolean isFavorite() {
+        return favorite;
     }
 
     public List<TagDto> getTags() {

--- a/src/main/java/com/funeat/review/dto/RankingReviewDto.java
+++ b/src/main/java/com/funeat/review/dto/RankingReviewDto.java
@@ -5,38 +5,20 @@ import com.funeat.review.domain.ReviewTag;
 import com.funeat.tag.dto.TagDto;
 import java.util.List;
 
-public class RankingReviewDto {
-
-    private final Long id;
-    private final String userName;
-    private final String profileImage;
-    private final Long productId;
-    private final String productName;
-    private final String content;
-    private final String image;
-    private final Long rating;
-    private final boolean rebuy;
-    private final Long favoriteCount;
-    private final boolean favorite;
-    private final List<TagDto> tags;
-
-    private RankingReviewDto(final Long id, final String userName, final String profileImage, final Long productId,
-                             final String productName, final String content, final String image,
-                             final Long rating, final boolean rebuy, final Long favoriteCount, final boolean favorite,
-                             final List<TagDto> tags) {
-        this.id = id;
-        this.userName = userName;
-        this.profileImage = profileImage;
-        this.productId = productId;
-        this.productName = productName;
-        this.content = content;
-        this.image = image;
-        this.rating = rating;
-        this.rebuy = rebuy;
-        this.favoriteCount = favoriteCount;
-        this.favorite = favorite;
-        this.tags = tags;
-    }
+public record RankingReviewDto(
+        Long id,
+        String userName,
+        String profileImage,
+        Long productId,
+        String productName,
+        String content,
+        String image,
+        Long rating,
+        boolean rebuy,
+        Long favoriteCount,
+        boolean favorite,
+        List<TagDto> tags
+) {
 
     public static RankingReviewDto toDto(final Review review, final Boolean favorite) {
         final List<TagDto> tagDtos = review.getReviewTags().stream()
@@ -58,53 +40,5 @@ public class RankingReviewDto {
                 favorite,
                 tagDtos
         );
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getUserName() {
-        return userName;
-    }
-
-    public String getProfileImage() {
-        return profileImage;
-    }
-
-    public Long getProductId() {
-        return productId;
-    }
-
-    public String getProductName() {
-        return productName;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public String getImage() {
-        return image;
-    }
-
-    public Long getRating() {
-        return rating;
-    }
-
-    public boolean isRebuy() {
-        return rebuy;
-    }
-
-    public Long getFavoriteCount() {
-        return favoriteCount;
-    }
-
-    public boolean isFavorite() {
-        return favorite;
-    }
-
-    public List<TagDto> getTags() {
-        return tags;
     }
 }

--- a/src/main/java/com/funeat/review/dto/RankingReviewDto.java
+++ b/src/main/java/com/funeat/review/dto/RankingReviewDto.java
@@ -14,9 +14,9 @@ public record RankingReviewDto(
         String content,
         String image,
         Long rating,
-        boolean rebuy,
+        Boolean rebuy,
         Long favoriteCount,
-        boolean favorite,
+        Boolean favorite,
         List<TagDto> tags
 ) {
 

--- a/src/main/java/com/funeat/review/dto/RankingReviewsResponse.java
+++ b/src/main/java/com/funeat/review/dto/RankingReviewsResponse.java
@@ -2,19 +2,11 @@ package com.funeat.review.dto;
 
 import java.util.List;
 
-public class RankingReviewsResponse {
-
-    private final List<RankingReviewDto> reviews;
-
-    public RankingReviewsResponse(final List<RankingReviewDto> reviews) {
-        this.reviews = reviews;
-    }
+public record RankingReviewsResponse(
+        List<RankingReviewDto> reviews
+) {
 
     public static RankingReviewsResponse toResponse(final List<RankingReviewDto> reviews) {
         return new RankingReviewsResponse(reviews);
-    }
-
-    public List<RankingReviewDto> getReviews() {
-        return reviews;
     }
 }

--- a/src/main/java/com/funeat/review/presentation/ReviewApiController.java
+++ b/src/main/java/com/funeat/review/presentation/ReviewApiController.java
@@ -11,9 +11,9 @@ import com.funeat.review.dto.ReviewDetailResponse;
 import com.funeat.review.dto.ReviewFavoriteRequest;
 import com.funeat.review.dto.SortingReviewRequest;
 import com.funeat.review.dto.SortingReviewsResponse;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.Optional;
-import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -68,8 +68,8 @@ public class ReviewApiController implements ReviewController {
     }
 
     @GetMapping("/api/ranks/reviews")
-    public ResponseEntity<RankingReviewsResponse> getRankingReviews() {
-        final RankingReviewsResponse response = reviewService.getTopReviews();
+    public ResponseEntity<RankingReviewsResponse> getRankingReviews(@AuthenticationPrincipal final LoginInfo loginInfo) {
+        final RankingReviewsResponse response = reviewService.getTopReviews(loginInfo.getId());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -64,7 +64,7 @@ public interface ReviewController {
             description = "리뷰 랭킹 Top3 조회 성공."
     )
     @GetMapping
-    ResponseEntity<RankingReviewsResponse> getRankingReviews();
+    ResponseEntity<RankingReviewsResponse> getRankingReviews(@AuthenticationPrincipal final LoginInfo loginInfo);
 
     @Operation(summary = "좋아요를 제일 많은 받은 리뷰 조회", description = "특정 상품에 대해 좋아요를 제일 많이 받은 리뷰를 조회한다.")
     @ApiResponse(

--- a/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -10,7 +10,6 @@ import static com.funeat.acceptance.common.CommonSteps.정상_생성;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리_NO_CONTENT;
 import static com.funeat.acceptance.common.CommonSteps.찾을수_없음;
-import static com.funeat.acceptance.product.ProductSteps.상품_상세_조회_요청;
 import static com.funeat.acceptance.review.ReviewSteps.리뷰_랭킹_조회_요청;
 import static com.funeat.acceptance.review.ReviewSteps.리뷰_상세_조회_요청;
 import static com.funeat.acceptance.review.ReviewSteps.리뷰_작성_요청;
@@ -852,7 +851,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         final var actual = response.jsonPath()
                 .getList("reviews", RankingReviewDto.class);
 
-        assertThat(actual).extracting(RankingReviewDto::getReviewId)
+        assertThat(actual).extracting(RankingReviewDto::getId)
                 .containsExactlyElementsOf(reviewIds);
     }
 

--- a/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -878,9 +878,9 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         final var actual = response.jsonPath()
                 .getList("reviews", RankingReviewDto.class);
 
-        assertThat(actual).extracting(RankingReviewDto::getId)
+        assertThat(actual).extracting(RankingReviewDto::id)
                 .containsExactlyElementsOf(reviewIds);
-        assertThat(actual).extracting(RankingReviewDto::isFavorite)
+        assertThat(actual).extracting(RankingReviewDto::favorite)
                 .isEqualTo(favorites);
     }
 

--- a/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
+++ b/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
@@ -88,6 +88,15 @@ public class ReviewSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 리뷰_랭킹_조회_요청(final String loginCookie) {
+        return given()
+                .cookie("SESSION", loginCookie)
+                .when()
+                .get("/api/ranks/reviews")
+                .then()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 좋아요를_제일_많이_받은_리뷰_조회_요청(final Long productId) {
         return given()
                 .when()

--- a/src/test/java/com/funeat/fixture/ReviewFixture.java
+++ b/src/test/java/com/funeat/fixture/ReviewFixture.java
@@ -6,6 +6,7 @@ import static com.funeat.fixture.PageFixture.평점_내림차순;
 import static com.funeat.fixture.PageFixture.평점_오름차순;
 
 import com.funeat.member.domain.Member;
+import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.product.domain.Product;
 import com.funeat.review.domain.Review;
 import com.funeat.review.dto.ReviewCreateRequest;
@@ -100,6 +101,10 @@ public class ReviewFixture {
 
     public static ReviewFavoriteRequest 리뷰좋아요요청_생성(final Boolean favorite) {
         return new ReviewFavoriteRequest(favorite);
+    }
+
+    public static ReviewFavorite 리뷰_좋아요_생성(final Member member, final Review review, final Boolean favorite) {
+        return ReviewFavorite.create(member, review, favorite);
     }
 
     public static SortingReviewRequest 리뷰정렬요청_좋아요수_내림차순_생성(final Long lastReviewId) {

--- a/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -23,6 +23,7 @@ import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test4_평점4점_재구매O_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test5_평점5점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지없음_평점1점_재구매O_생성;
+import static com.funeat.fixture.ReviewFixture.리뷰_좋아요_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰정렬요청_좋아요수_내림차순_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰정렬요청_최신순_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰정렬요청_평점_내림차순_생성;
@@ -1335,6 +1336,70 @@ class ReviewServiceTest extends ServiceTest {
                 final var rankingReviewDto1 = RankingReviewDto.toDto(review1, false);
                 final var rankingReviewDto2 = RankingReviewDto.toDto(review2, false);
                 final var rankingReviewDtos = List.of(rankingReviewDto2, rankingReviewDto1);
+                final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
+
+                // when
+                final var actual = reviewService.getTopReviews(loginId);
+
+                // then
+                assertThat(actual).usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class 로그인_여부_응답_테스트 {
+
+            @Test
+            void 로그인_안한_경우_리뷰_좋아요는_false로_반환한다() {
+                // given
+                final var loginId = -1L;
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
+
+                final var product = 상품_삼각김밥_가격1000원_평점4점_생성(category);
+                단일_상품_저장(product);
+
+                final var member = 멤버_멤버1_생성();
+                단일_멤버_저장(member);
+
+                final var now = LocalDateTime.now();
+                final var review = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 1L, now.minusDays(1L));
+                단일_리뷰_저장(review);
+
+                final var rankingReviewDto = RankingReviewDto.toDto(review, false);
+                final var rankingReviewDtos = List.of(rankingReviewDto);
+                final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
+
+                // when
+                final var actual = reviewService.getTopReviews(loginId);
+
+                // then
+                assertThat(actual).usingRecursiveComparison()
+                        .isEqualTo(expected);
+            }
+
+            @Test
+            void 로그인_한_경우_리뷰_좋아요는_로그인한_사용자에_따라_반환한다() {
+                // given
+                final var member = 멤버_멤버1_생성();
+                단일_멤버_저장(member);
+                final var loginId = member.getId();
+                final var category = 카테고리_간편식사_생성();
+                단일_카테고리_저장(category);
+
+                final var product = 상품_삼각김밥_가격1000원_평점4점_생성(category);
+                단일_상품_저장(product);
+
+                final var now = LocalDateTime.now();
+                final var review = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 1L, now.minusDays(1L));
+                단일_리뷰_저장(review);
+
+                final var reviewFavorite = 리뷰_좋아요_생성(member, review, true);
+                단일_리뷰_좋아요_저장(reviewFavorite);
+
+                final var rankingReviewDto = RankingReviewDto.toDto(review, true);
+                final var rankingReviewDtos = List.of(rankingReviewDto);
                 final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
 
                 // when

--- a/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -1206,10 +1206,11 @@ class ReviewServiceTest extends ServiceTest {
             @Test
             void 전체_리뷰가_하나도_없어도_반환값은_있어야한다() {
                 // given
+                final var loginId = -1L;
                 final var expected = RankingReviewsResponse.toResponse(Collections.emptyList());
 
                 // when
-                final var actual = reviewService.getTopReviews();
+                final var actual = reviewService.getTopReviews(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -1219,6 +1220,7 @@ class ReviewServiceTest extends ServiceTest {
             @Test
             void 전체_리뷰가_1개라도_리뷰가_나와야한다() {
                 // given
+                final var loginId = -1L;
                 final var category = 카테고리_간편식사_생성();
                 단일_카테고리_저장(category);
 
@@ -1232,12 +1234,12 @@ class ReviewServiceTest extends ServiceTest {
                 final var review = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 2L, now.minusDays(1L));
                 단일_리뷰_저장(review);
 
-                final var rankingReviewDto = RankingReviewDto.toDto(review);
+                final var rankingReviewDto = RankingReviewDto.toDto(review, false);
                 final var rankingReviewDtos = List.of(rankingReviewDto);
                 final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
 
                 // when
-                final var actual = reviewService.getTopReviews();
+                final var actual = reviewService.getTopReviews(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -1247,6 +1249,7 @@ class ReviewServiceTest extends ServiceTest {
             @Test
             void 전체_리뷰_중_랭킹이_높은_상위_2개_리뷰를_구할_수_있다() {
                 // given
+                final var loginId = -1L;
                 final var category = 카테고리_간편식사_생성();
                 단일_카테고리_저장(category);
 
@@ -1262,14 +1265,14 @@ class ReviewServiceTest extends ServiceTest {
                 final var review3 = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 4L, now);
                 복수_리뷰_저장(review1, review2, review3);
 
-                final var rankingReviewDto1 = RankingReviewDto.toDto(review1);
-                final var rankingReviewDto2 = RankingReviewDto.toDto(review2);
-                final var rankingReviewDto3 = RankingReviewDto.toDto(review3);
+                final var rankingReviewDto1 = RankingReviewDto.toDto(review1, false);
+                final var rankingReviewDto2 = RankingReviewDto.toDto(review2, false);
+                final var rankingReviewDto3 = RankingReviewDto.toDto(review3, false);
                 final var rankingReviewDtos = List.of(rankingReviewDto3, rankingReviewDto2);
                 final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
 
                 // when
-                final var actual = reviewService.getTopReviews();
+                final var actual = reviewService.getTopReviews(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -1283,6 +1286,7 @@ class ReviewServiceTest extends ServiceTest {
             @Test
             void 리뷰_좋아요_수가_같으면_최근_생성된_리뷰의_랭킹을_더_높게_반환한다() {
                 // given
+                final var loginId = -1L;
                 final var category = 카테고리_간편식사_생성();
                 단일_카테고리_저장(category);
 
@@ -1297,13 +1301,13 @@ class ReviewServiceTest extends ServiceTest {
                 final var review2 = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 10L, now.minusDays(4L));
                 복수_리뷰_저장(review1, review2);
 
-                final var rankingReviewDto1 = RankingReviewDto.toDto(review1);
-                final var rankingReviewDto2 = RankingReviewDto.toDto(review2);
+                final var rankingReviewDto1 = RankingReviewDto.toDto(review1, false);
+                final var rankingReviewDto2 = RankingReviewDto.toDto(review2, false);
                 final var rankingReviewDtos = List.of(rankingReviewDto2, rankingReviewDto1);
                 final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
 
                 // when
-                final var actual = reviewService.getTopReviews();
+                final var actual = reviewService.getTopReviews(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()
@@ -1313,6 +1317,7 @@ class ReviewServiceTest extends ServiceTest {
             @Test
             void 리뷰_생성_일자가_같으면_좋아요_수가_많은_리뷰의_랭킹을_더_높게_반환한다() {
                 // given
+                final var loginId = -1L;
                 final var category = 카테고리_간편식사_생성();
                 단일_카테고리_저장(category);
 
@@ -1327,13 +1332,13 @@ class ReviewServiceTest extends ServiceTest {
                 final var review2 = 리뷰_이미지test5_평점5점_재구매X_생성(member, product, 4L, now.minusDays(1L));
                 복수_리뷰_저장(review1, review2);
 
-                final var rankingReviewDto1 = RankingReviewDto.toDto(review1);
-                final var rankingReviewDto2 = RankingReviewDto.toDto(review2);
+                final var rankingReviewDto1 = RankingReviewDto.toDto(review1, false);
+                final var rankingReviewDto2 = RankingReviewDto.toDto(review2, false);
                 final var rankingReviewDtos = List.of(rankingReviewDto2, rankingReviewDto1);
                 final var expected = RankingReviewsResponse.toResponse(rankingReviewDtos);
 
                 // when
-                final var actual = reviewService.getTopReviews();
+                final var actual = reviewService.getTopReviews(loginId);
 
                 // then
                 assertThat(actual).usingRecursiveComparison()


### PR DESCRIPTION
## Issue

- close #73 

## ✨ 구현한 기능

- 리뷰 랭킹 조회 DTO 수정
  - [수정] reviewId -> id
  - [추가] userName
  - [추가] profileImage
  - [추가] rating
  - [추가] rebuy
  - [추가] favorite
  - [추가] favoriteCount
  - [삭제] categoryType

- 로그인 여부에 따른 로직 분리

## 📢 논의하고 싶은 내용

X

## 🎸 기타

- DTO 수정하는 김에 record로 타입 변경했습니다.

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 2h
