### PR TITLE
fix: 최신순 정렬을 사용하는 ServiceTest, RepositoryTest에 아이디 기준 내림차순 옵션 추가

### DIFF
--- a/src/test/java/com/funeat/fixture/PageFixture.java
+++ b/src/test/java/com/funeat/fixture/PageFixture.java
@@ -6,6 +6,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @SuppressWarnings("NonAsciiCharacters")
 public class PageFixture {
 
@@ -34,12 +38,16 @@ public class PageFixture {
         return PageRequest.of(page, size);
     }
 
-    public static PageRequest 페이지요청_생성(final int page, final int size, final String sort) {
-        final String[] splitSort = sort.split(",");
-        final String order = splitSort[0];
-        final Direction direction = Direction.fromString(splitSort[1]);
+    public static PageRequest 페이지요청_생성(final int page, final int size, final String... sorts) {
+        final List<Sort.Order> orders = new ArrayList<>();
+        Arrays.stream(sorts).forEach(sort -> {
+            final String[] splitSort = sort.split(",");
+            final String property = splitSort[0];
+            final Direction direction = Direction.fromString(splitSort[1]);
+            orders.add(new Sort.Order(direction, property));
+        });
 
-        return PageRequest.of(page, size, Sort.by(direction, order));
+        return PageRequest.of(page, size, Sort.by(orders));
     }
 
     public static PageDto 응답_페이지_생성(final Long totalDataCount, final Long totalPages, final boolean firstPage,

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -7,6 +7,7 @@ import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
 import static com.funeat.fixture.PageFixture.과거순;
+import static com.funeat.fixture.PageFixture.아이디_내림차순;
 import static com.funeat.fixture.PageFixture.좋아요수_내림차순;
 import static com.funeat.fixture.PageFixture.최신순;
 import static com.funeat.fixture.PageFixture.페이지요청_생성;
@@ -219,7 +220,7 @@ class RecipeServiceTest extends ServiceTest {
             final var recipeImage1_2 = 레시피이미지_생성(recipe1_2);
             복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage1_2);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeService.findRecipeByMember(member1.getId(), page);
@@ -240,7 +241,7 @@ class RecipeServiceTest extends ServiceTest {
             final var member1 = 멤버_멤버1_생성();
             단일_멤버_저장(member1);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeService.findRecipeByMember(member1.getId(), page);
@@ -260,7 +261,7 @@ class RecipeServiceTest extends ServiceTest {
         void 존재하지_않는_멤버가_해당_멤버의_레시피를_조회하면_예외가_발생한다() {
             // given
             final var notExistMemberId = 99999L;
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when & then
             assertThatThrownBy(() -> recipeService.findRecipeByMember(notExistMemberId, page))
@@ -327,7 +328,7 @@ class RecipeServiceTest extends ServiceTest {
             }
 
             @Test
-            void 꿀조합을_최신순으로_정렬할_수_있다() throws InterruptedException {
+            void 꿀조합을_최신순으로_정렬할_수_있다() {
                 // given
                 final var loginId = -1L;
                 final var member1 = 멤버_멤버1_생성();
@@ -344,9 +345,7 @@ class RecipeServiceTest extends ServiceTest {
                 복수_상품_저장(product1, product2, product3);
 
                 final var recipe1_1 = 레시피_생성(member1, 1L);
-                Thread.sleep(100);
                 final var recipe1_2 = 레시피_생성(member1, 3L);
-                Thread.sleep(100);
                 final var recipe1_3 = 레시피_생성(member1, 2L);
                 복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
 
@@ -363,7 +362,7 @@ class RecipeServiceTest extends ServiceTest {
                 final var recipeImage1_2_2 = 레시피이미지_생성(recipe1_2);
                 복수_꿀조합_이미지_저장(recipeImage1_1_1, recipeImage1_2_1);
 
-                final var page = 페이지요청_생성(0, 10, 최신순);
+                final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
                 // when
                 final var actual = recipeService.getSortingRecipes(loginId, page).getRecipes();
@@ -818,7 +817,7 @@ class RecipeServiceTest extends ServiceTest {
             final var request = 레시피북마크요청_생성(북마크O);
             recipeService.bookmarkRecipe(member1.getId(), recipe2.getId(), request);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeService.findBookmarkRecipeByMember(member1.getId(), page);
@@ -843,7 +842,7 @@ class RecipeServiceTest extends ServiceTest {
             final var member1 = 멤버_멤버1_생성();
             단일_멤버_저장(member1);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeService.findBookmarkRecipeByMember(member1.getId(), page);
@@ -863,7 +862,7 @@ class RecipeServiceTest extends ServiceTest {
         void 존재하지_않는_멤버가_해당_멤버의_저장한_레시피를_조회하면_예외가_발생한다() {
             // given
             final var notExistMemberId = 99999L;
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when & then
             assertThatThrownBy(() -> recipeService.findBookmarkRecipeByMember(notExistMemberId, page))

--- a/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
+++ b/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
@@ -5,6 +5,7 @@ import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
 import static com.funeat.fixture.PageFixture.과거순;
+import static com.funeat.fixture.PageFixture.아이디_내림차순;
 import static com.funeat.fixture.PageFixture.좋아요수_내림차순;
 import static com.funeat.fixture.PageFixture.최신순;
 import static com.funeat.fixture.PageFixture.페이지요청_생성;
@@ -166,7 +167,7 @@ class RecipeRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 꿀조합을_최신순으로_정렬한다() throws InterruptedException {
+        void 꿀조합을_최신순으로_정렬한다() {
             // given
             final var member1 = 멤버_멤버1_생성();
             final var member2 = 멤버_멤버2_생성();
@@ -182,9 +183,7 @@ class RecipeRepositoryTest extends RepositoryTest {
             복수_상품_저장(product1, product2, product3);
 
             final var recipe1_1 = 레시피_생성(member1, 1L);
-            Thread.sleep(100);
             final var recipe1_2 = 레시피_생성(member1, 3L);
-            Thread.sleep(100);
             final var recipe1_3 = 레시피_생성(member1, 2L);
             복수_꿀조합_저장(recipe1_1, recipe1_2, recipe1_3);
 
@@ -200,7 +199,7 @@ class RecipeRepositoryTest extends RepositoryTest {
             final var recipeImage1_2 = 레시피이미지_생성(recipe1_2);
             복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage1_2);
 
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
             final var expected = List.of(recipe1_3, recipe1_2, recipe1_1);
 
             // when
@@ -371,7 +370,7 @@ class RecipeRepositoryTest extends RepositoryTest {
             복수_레시피_북마크_저장(bookmarkRecipe1, bookmarkRecipe2, bookmarkRecipe3);
 
             final var expected = List.of(recipe3, recipe2);
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeRepository.findBookmarkedRecipesByMember(member, page).getContent();
@@ -392,7 +391,7 @@ class RecipeRepositoryTest extends RepositoryTest {
             복수_꿀조합_저장(recipe1, recipe2);
 
             final var expected = Collections.emptyList();
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when
             final var actual = recipeRepository.findBookmarkedRecipesByMember(member, page).getContent();

--- a/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -6,6 +6,7 @@ import static com.funeat.fixture.ImageFixture.이미지_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_비로그인_생성;
+import static com.funeat.fixture.PageFixture.아이디_내림차순;
 import static com.funeat.fixture.PageFixture.최신순;
 import static com.funeat.fixture.PageFixture.페이지요청_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
@@ -674,7 +675,7 @@ class ReviewServiceTest extends ServiceTest {
             복수_리뷰_저장(review1_1, review2_1, review2_2, review3_1, review3_2);
 
             // when
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
             final var member1Id = member1.getId();
             final var result = reviewService.findReviewByMember(member1Id, page);
 
@@ -699,7 +700,7 @@ class ReviewServiceTest extends ServiceTest {
         void 존재하지_않은_사용자가_작성한_리뷰를_조회할때_예외가_발생한다() {
             // given
             final var notExistMemberId = 999999L;
-            final var page = 페이지요청_생성(0, 10, 최신순);
+            final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);
 
             // when & then
             assertThatThrownBy(() -> reviewService.findReviewByMember(notExistMemberId, page))


### PR DESCRIPTION
## Issue

- close #76

## ✨ 구현한 기능

- 최신순으로 정렬할 때, 아이디 기준 내림차순으로 정렬되는 조건도 고정적으로 추가하도록 했습니다.

## 📢 논의하고 싶은 내용

- 에러가 나온 이유 원인은 #34 와 동일합니다. 애초에 지금 PR 코드를 수정하는걸로 모든 최신순 테스트 실패를 해결할 수 있었네요

이것도 쿼리문은 소수점 6자리 기준으로 데이터가 나와서 id2, id3 순서로 나오게 됩니다. 근데 H2에서 가져온 데이터를 사용하는게 아니라 영속성 컨텍스트 1차 캐시 값을 재사용하고 있기 때문에 이상하게 결과값을 가져오는 것처럼 보이는 것입니다.

```
[Java - 영속성 컨텍스트 1차 캐시]
2번 데이터 = 11:00:21.498842569
3번 데이터 = 11:00:21.498843211

[H2 - 실제로 저장된 값]
2번 데이터 = 11:00:21.498843 (반올림)
3번 데이터 = 11:00:21.498843 (반올림)
```

[이전 쿼리문]

![스크린샷 2024-06-07 오후 9 03 37](https://github.com/fun-eat/funeat-server/assets/79046106/f47a6358-7e93-4f12-a073-9a671e536f0f)

[변경된 쿼리문]

![스크린샷 2024-06-07 오후 9 26 24](https://github.com/fun-eat/funeat-server/assets/79046106/765b7df0-5b3e-4f33-ad2d-4ceba20b057e)

## 🎸 기타

- 인수테스트에서 문제 없었던 이유

![스크린샷 2024-06-07 오후 9 30 10](https://github.com/fun-eat/funeat-server/assets/79046106/676d3a03-220a-422e-b44e-d6059be39bee)

요청이 오면 기존 정렬 조건에 추가적으로 id 기준 내림차순을 적용해놨어서 🤣

![스크린샷 2024-06-07 오후 9 34 49](https://github.com/fun-eat/funeat-server/assets/79046106/afe2e12c-c7f3-434d-9eaa-9dd3d05c6567)

## ⏰ 일정

- 추정 시간 : 30분
- 걸린 시간 : 35분