### PR TITLE
refactor: 레시피 저장 리팩터링

### DIFF
--- a/src/main/java/com/funeat/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/funeat/member/exception/MemberErrorCode.java
@@ -7,7 +7,7 @@ public enum MemberErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다. 회원 id를 확인하세요.", "5001"),
     MEMBER_UPDATE_ERROR(HttpStatus.BAD_REQUEST, "닉네임 또는 이미지를 확인하세요.", "5002"),
     MEMBER_DUPLICATE_FAVORITE(HttpStatus.CONFLICT, "이미 좋아요를 누른 상태입니다.", "5003"),
-    MEMBER_DUPLICATE_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크를 누른 상태입니다.", "5004"),
+    MEMBER_DUPLICATE_BOOKMARK(HttpStatus.CONFLICT, "이미 저장을 누른 상태입니다.", "5004"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/funeat/recipe/dto/RecipeBookmarkRequest.java
+++ b/src/main/java/com/funeat/recipe/dto/RecipeBookmarkRequest.java
@@ -3,7 +3,7 @@ package com.funeat.recipe.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record RecipeBookmarkRequest (
-        @NotNull(message = "북마크를 확인해주세요")
+        @NotNull(message = "레시피 저장 기능을 확인해주세요")
         Boolean bookmark
 ) {
 }

--- a/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
@@ -13,10 +13,10 @@ import static com.funeat.acceptance.common.CommonSteps.페이지를_검증한다
 import static com.funeat.acceptance.member.MemberSteps.리뷰_삭제_요청;
 import static com.funeat.acceptance.member.MemberSteps.사용자_꿀조합_조회_요청;
 import static com.funeat.acceptance.member.MemberSteps.사용자_리뷰_조회_요청;
-import static com.funeat.acceptance.member.MemberSteps.사용자_북마크한_꿀조합_조회_요청;
+import static com.funeat.acceptance.member.MemberSteps.사용자_저장한_꿀조합_조회_요청;
 import static com.funeat.acceptance.member.MemberSteps.사용자_정보_수정_요청;
 import static com.funeat.acceptance.member.MemberSteps.사용자_정보_조회_요청;
-import static com.funeat.acceptance.recipe.RecipeSteps.레시피_북마크_요청;
+import static com.funeat.acceptance.recipe.RecipeSteps.레시피_저장_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_작성_요청;
 import static com.funeat.acceptance.review.ReviewSteps.리뷰_작성_요청;
 import static com.funeat.auth.exception.AuthErrorCode.LOGIN_MEMBER_NOT_FOUND;
@@ -43,10 +43,10 @@ import static com.funeat.fixture.RecipeFixture.레시피;
 import static com.funeat.fixture.RecipeFixture.레시피1;
 import static com.funeat.fixture.RecipeFixture.레시피2;
 import static com.funeat.fixture.RecipeFixture.레시피3;
-import static com.funeat.fixture.RecipeFixture.레시피북마크요청_생성;
+import static com.funeat.fixture.RecipeFixture.레시피저장요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피추가요청_생성;
-import static com.funeat.fixture.RecipeFixture.북마크O;
-import static com.funeat.fixture.RecipeFixture.북마크X;
+import static com.funeat.fixture.RecipeFixture.저장O;
+import static com.funeat.fixture.RecipeFixture.저장X;
 import static com.funeat.fixture.ReviewFixture.리뷰1;
 import static com.funeat.fixture.ReviewFixture.리뷰2;
 import static com.funeat.fixture.ReviewFixture.리뷰추가요청_재구매O_생성;
@@ -416,12 +416,12 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(0L), 총_페이지(0L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
 
             // when
-            final var 응답 = 사용자_북마크한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
+            final var 응답 = 사용자_저장한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리);
             페이지를_검증한다(응답, 예상_응답_페이지);
-            사용자_북마크한_꿀조합_조회_결과를_검증한다(응답, Collections.emptyList());
+            사용자_저장한_꿀조합_조회_결과를_검증한다(응답, Collections.emptyList());
         }
 
         @Test
@@ -435,18 +435,18 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지2), 레시피추가요청_생성(상품));
             레시피_작성_요청(로그인_쿠키_획득(멤버2), 여러개_사진_명세_요청(이미지3), 레시피추가요청_생성(상품));
 
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피북마크요청_생성(북마크O));
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피3, 레시피북마크요청_생성(북마크O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피저장요청_생성(저장O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피3, 레시피저장요청_생성(저장O));
 
             final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(2L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
 
             // when
-            final var 응답 = 사용자_북마크한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
+            final var 응답 = 사용자_저장한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리);
             페이지를_검증한다(응답, 예상_응답_페이지);
-            사용자_북마크한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피3, 레시피1));
+            사용자_저장한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피3, 레시피1));
         }
 
         @Test
@@ -459,20 +459,20 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
             레시피_작성_요청(로그인_쿠키_획득(멤버2), 여러개_사진_명세_요청(이미지2), 레시피추가요청_생성(상품));
 
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피북마크요청_생성(북마크O));
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피2, 레시피북마크요청_생성(북마크O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피저장요청_생성(저장O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피2, 레시피저장요청_생성(저장O));
 
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피북마크요청_생성(북마크X));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피저장요청_생성(저장X));
 
             final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(1L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
 
             // when
-            final var 응답 = 사용자_북마크한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
+            final var 응답 = 사용자_저장한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리);
             페이지를_검증한다(응답, 예상_응답_페이지);
-            사용자_북마크한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피2));
+            사용자_저장한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피2));
         }
 
         @Test
@@ -483,17 +483,17 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             final var 상품 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점5점_생성(카테고리));
 
             레시피_작성_요청(로그인_쿠키_획득(멤버1), null, 레시피추가요청_생성(상품));
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피북마크요청_생성(북마크O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피1, 레시피저장요청_생성(저장O));
 
             final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(1L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
 
             // when
-            final var 응답 = 사용자_북마크한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
+            final var 응답 = 사용자_저장한_꿀조합_조회_요청(로그인_쿠키_획득(멤버1), FIRST_PAGE);
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리);
             페이지를_검증한다(응답, 예상_응답_페이지);
-            사용자_북마크한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피));
+            사용자_저장한_꿀조합_조회_결과를_검증한다(응답, List.of(레시피));
             조회한_꿀조합의_이미지가_없는지_확인한다(응답);
         }
     }
@@ -505,7 +505,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @NullAndEmptySource
         void 로그인하지_않은_사용자가_저장한_꿀조합을_조회할때_예외가_발생한다(final String cookie) {
             // given & when
-            final var 응답 = 사용자_북마크한_꿀조합_조회_요청(cookie, FIRST_PAGE);
+            final var 응답 = 사용자_저장한_꿀조합_조회_요청(cookie, FIRST_PAGE);
 
             // then
             STATUS_CODE를_검증한다(응답, 인증되지_않음);
@@ -570,8 +570,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(actual).isNull();
     }
 
-    private void 사용자_북마크한_꿀조합_조회_결과를_검증한다(final ExtractableResponse<Response> response,
-                                          final List<Long> recipeIds) {
+    private void 사용자_저장한_꿀조합_조회_결과를_검증한다(final ExtractableResponse<Response> response,
+                                         final List<Long> recipeIds) {
         final var actual = response.jsonPath()
                 .getList("recipes", MemberBookmarkRecipeDto.class);
 

--- a/src/test/java/com/funeat/acceptance/member/MemberSteps.java
+++ b/src/test/java/com/funeat/acceptance/member/MemberSteps.java
@@ -72,7 +72,7 @@ public class MemberSteps {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 사용자_북마크한_꿀조합_조회_요청(final String loginCookie, final Long page) {
+    public static ExtractableResponse<Response> 사용자_저장한_꿀조합_조회_요청(final String loginCookie, final Long page) {
         return given()
                 .when()
                 .cookie("SESSION", loginCookie)

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -15,7 +15,7 @@ import static com.funeat.acceptance.recipe.RecipeSteps.레시피_댓글_작성_�
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_댓글_조회_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_랭킹_조회_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_목록_요청;
-import static com.funeat.acceptance.recipe.RecipeSteps.레시피_북마크_요청;
+import static com.funeat.acceptance.recipe.RecipeSteps.레시피_저장_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_상세_정보_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_작성_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_좋아요_요청;
@@ -59,11 +59,11 @@ import static com.funeat.fixture.RecipeFixture.레시피8;
 import static com.funeat.fixture.RecipeFixture.레시피9;
 import static com.funeat.fixture.RecipeFixture.레시피_본문;
 import static com.funeat.fixture.RecipeFixture.레시피_제목;
-import static com.funeat.fixture.RecipeFixture.레시피북마크요청_생성;
+import static com.funeat.fixture.RecipeFixture.레시피저장요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피좋아요요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피추가요청_생성;
-import static com.funeat.fixture.RecipeFixture.북마크O;
-import static com.funeat.fixture.RecipeFixture.북마크X;
+import static com.funeat.fixture.RecipeFixture.저장O;
+import static com.funeat.fixture.RecipeFixture.저장X;
 import static com.funeat.fixture.RecipeFixture.존재하지_않는_레시피;
 import static com.funeat.fixture.RecipeFixture.좋아요O;
 import static com.funeat.fixture.RecipeFixture.좋아요X;
@@ -381,7 +381,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     class bookmarkRecipe_성공_테스트 {
 
         @Test
-        void 레시피에_북마크를_할_수_있다() {
+        void 레시피_저장을_할_수_있다() {
             // given
             final var 카테고리 = 카테고리_간편식사_생성();
             단일_카테고리_저장(카테고리);
@@ -390,24 +390,24 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
 
             // when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크O));
+            final var 응답 = 레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피저장요청_생성(저장O));
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리_NO_CONTENT);
         }
 
         @Test
-        void 레시피예_북마크를_취소할_수_있다() {
+        void 레시피_저장을_취소할_수_있다() {
             // given
             final var 카테고리 = 카테고리_간편식사_생성();
             단일_카테고리_저장(카테고리);
             final var 상품 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크O));
+            레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피저장요청_생성(저장O));
 
             // when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크X));
+            final var 응답 = 레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피저장요청_생성(저장X));
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리_NO_CONTENT);
@@ -428,7 +428,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
 
             // when
-            final var 응답 = 레시피_북마크_요청(cookie, 레시피, 레시피북마크요청_생성(북마크O));
+            final var 응답 = 레시피_저장_요청(cookie, 레시피, 레시피저장요청_생성(저장O));
 
             // then
             STATUS_CODE를_검증한다(응답, 인증되지_않음);
@@ -446,18 +446,18 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
 
             // when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(null));
+            final var 응답 = 레시피_저장_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피저장요청_생성(null));
 
             // then
             STATUS_CODE를_검증한다(응답, 잘못된_요청);
             RESPONSE_CODE와_MESSAGE를_검증한다(응답, REQUEST_VALID_ERROR_CODE.getCode(),
-                    "북마크를 확인해주세요. " + REQUEST_VALID_ERROR_CODE.getMessage());
+                    "레시피 저장 기능을 확인해주세요. " + REQUEST_VALID_ERROR_CODE.getMessage());
         }
 
         @Test
         void 존재하지_않는_레시피에_사용자가_저장할_때_예외가_발생한다() {
             // given & when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 존재하지_않는_레시피, 레시피북마크요청_생성(북마크O));
+            final var 응답 = 레시피_저장_요청(로그인_쿠키_획득(멤버1), 존재하지_않는_레시피, 레시피저장요청_생성(저장O));
 
             // then
             STATUS_CODE를_검증한다(응답, 찾을수_없음);

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -62,6 +62,8 @@ import static com.funeat.fixture.RecipeFixture.레시피_제목;
 import static com.funeat.fixture.RecipeFixture.레시피북마크요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피좋아요요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피추가요청_생성;
+import static com.funeat.fixture.RecipeFixture.북마크O;
+import static com.funeat.fixture.RecipeFixture.북마크X;
 import static com.funeat.fixture.RecipeFixture.존재하지_않는_레시피;
 import static com.funeat.fixture.RecipeFixture.좋아요O;
 import static com.funeat.fixture.RecipeFixture.좋아요X;
@@ -388,7 +390,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
 
             // when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(좋아요O));
+            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크O));
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리_NO_CONTENT);
@@ -402,10 +404,10 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             final var 상품 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
-            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(좋아요O));
+            레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크O));
 
             // when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(좋아요X));
+            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 레시피, 레시피북마크요청_생성(북마크X));
 
             // then
             STATUS_CODE를_검증한다(응답, 정상_처리_NO_CONTENT);
@@ -426,7 +428,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             레시피_작성_요청(로그인_쿠키_획득(멤버1), 여러개_사진_명세_요청(이미지1), 레시피추가요청_생성(상품));
 
             // when
-            final var 응답 = 레시피_북마크_요청(cookie, 레시피, 레시피북마크요청_생성(좋아요O));
+            final var 응답 = 레시피_북마크_요청(cookie, 레시피, 레시피북마크요청_생성(북마크O));
 
             // then
             STATUS_CODE를_검증한다(응답, 인증되지_않음);
@@ -455,7 +457,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         @Test
         void 존재하지_않는_레시피에_사용자가_저장할_때_예외가_발생한다() {
             // given & when
-            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 존재하지_않는_레시피, 레시피북마크요청_생성(좋아요O));
+            final var 응답 = 레시피_북마크_요청(로그인_쿠키_획득(멤버1), 존재하지_않는_레시피, 레시피북마크요청_생성(북마크O));
 
             // then
             STATUS_CODE를_검증한다(응답, 찾을수_없음);

--- a/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -88,8 +88,8 @@ public class RecipeSteps {
         }
     }
 
-    public static ExtractableResponse<Response> 레시피_북마크_요청(final String loginCookie, final Long recipeId,
-                                                           final RecipeBookmarkRequest request) {
+    public static ExtractableResponse<Response> 레시피_저장_요청(final String loginCookie, final Long recipeId,
+                                                          final RecipeBookmarkRequest request) {
         return given()
                 .cookie("SESSION", loginCookie)
                 .contentType("application/json")

--- a/src/test/java/com/funeat/common/RepositoryTest.java
+++ b/src/test/java/com/funeat/common/RepositoryTest.java
@@ -198,7 +198,7 @@ public abstract class RepositoryTest {
         recipeFavoriteRepository.save(recipeFavorite);
     }
 
-    protected void 복수_레시피_북마크_저장(final RecipeBookmark... recipeBookmarksToSave) {
+    protected void 복수_저장한_레시피_저장(final RecipeBookmark... recipeBookmarksToSave) {
         final var recipeBookmarks = List.of(recipeBookmarksToSave);
 
         recipeBookmarkRepository.saveAll(recipeBookmarks);

--- a/src/test/java/com/funeat/fixture/RecipeFixture.java
+++ b/src/test/java/com/funeat/fixture/RecipeFixture.java
@@ -30,8 +30,8 @@ public class RecipeFixture {
 
     public static final boolean 좋아요O = true;
     public static final boolean 좋아요X = false;
-    public static final boolean 북마크O = true;
-    public static final boolean 북마크X = false;
+    public static final boolean 저장O = true;
+    public static final boolean 저장X = false;
 
     public static final String 레시피_제목 = "The most delicious recipes";
     public static final String 레시피_본문 = "More rice, more rice, more rice.. Done!!";
@@ -54,7 +54,7 @@ public class RecipeFixture {
         return new RecipeFavorite(member, recipe, favorite);
     }
 
-    public static RecipeBookmark 레시피_북마크_생성(final Member member, final Recipe recipe, final Boolean bookmark) {
+    public static RecipeBookmark 레시피_저장_생성(final Member member, final Recipe recipe, final Boolean bookmark) {
         return new RecipeBookmark(member, recipe, bookmark);
     }
 
@@ -74,7 +74,7 @@ public class RecipeFixture {
         return new RecipeFavoriteRequest(favorite);
     }
 
-    public static RecipeBookmarkRequest 레시피북마크요청_생성(final Boolean bookmark) {
+    public static RecipeBookmarkRequest 레시피저장요청_생성(final Boolean bookmark) {
         return new RecipeBookmarkRequest(bookmark);
     }
 

--- a/src/test/java/com/funeat/fixture/RecipeFixture.java
+++ b/src/test/java/com/funeat/fixture/RecipeFixture.java
@@ -74,8 +74,8 @@ public class RecipeFixture {
         return new RecipeFavoriteRequest(favorite);
     }
 
-    public static RecipeBookmarkRequest 레시피북마크요청_생성(final Boolean favorite) {
-        return new RecipeBookmarkRequest(favorite);
+    public static RecipeBookmarkRequest 레시피북마크요청_생성(final Boolean bookmark) {
+        return new RecipeBookmarkRequest(bookmark);
     }
 
     public static RecipeImage 레시피이미지_생성(final Recipe recipe) {

--- a/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -19,11 +19,11 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000원_평점4점_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_좋아요_생성;
-import static com.funeat.fixture.RecipeFixture.레시피북마크요청_생성;
+import static com.funeat.fixture.RecipeFixture.레시피저장요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
 import static com.funeat.fixture.RecipeFixture.레시피좋아요요청_생성;
 import static com.funeat.fixture.RecipeFixture.레시피추가요청_생성;
-import static com.funeat.fixture.RecipeFixture.북마크O;
+import static com.funeat.fixture.RecipeFixture.저장O;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -676,7 +676,7 @@ class RecipeServiceTest extends ServiceTest {
     class bookmarkRecipe_성공_테스트 {
 
         @Test
-        void 꿀조합에_북마크를_할_수_있다() {
+        void 꿀조합을_저장할_수_있다() {
             // given
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -698,7 +698,7 @@ class RecipeServiceTest extends ServiceTest {
             final var recipeId = recipeService.create(authorId, images, createRequest);
 
             // when
-            final var bookmarkRequest = 레시피북마크요청_생성(true);
+            final var bookmarkRequest = 레시피저장요청_생성(true);
             recipeService.bookmarkRecipe(memberId, recipeId, bookmarkRequest);
 
             final var actualRecipe = recipeRepository.findById(recipeId).get();
@@ -709,7 +709,7 @@ class RecipeServiceTest extends ServiceTest {
         }
 
         @Test
-        void 꿀조합에_북마크를_취소할_수_있다() {
+        void 저장한_꿀조합을_저장취소할_수_있다() {
             // given
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -730,11 +730,11 @@ class RecipeServiceTest extends ServiceTest {
             final var createRequest = 레시피추가요청_생성(productIds);
             final var recipeId = recipeService.create(authorId, images, createRequest);
 
-            final var bookmarkRequest = 레시피북마크요청_생성(true);
+            final var bookmarkRequest = 레시피저장요청_생성(true);
             recipeService.bookmarkRecipe(memberId, recipeId, bookmarkRequest);
 
             // when
-            final var cancelBookmarkRequest = 레시피북마크요청_생성(false);
+            final var cancelBookmarkRequest = 레시피저장요청_생성(false);
             recipeService.bookmarkRecipe(memberId, recipeId, cancelBookmarkRequest);
 
             final var actualRecipe = recipeRepository.findById(recipeId).get();
@@ -749,7 +749,7 @@ class RecipeServiceTest extends ServiceTest {
     class bookmarkRecipe_실패_테스트 {
 
         @Test
-        void 존재하지_않는_멤버가_레시피에_북마크를_하면_예외가_발생한다() {
+        void 존재하지_않는_멤버가_레시피를_저장하면_예외가_발생한다() {
             // given
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -770,13 +770,13 @@ class RecipeServiceTest extends ServiceTest {
             final var recipeId = recipeService.create(authorId, images, createRequest);
 
             // when & then
-            final var bookmarkRequest = 레시피북마크요청_생성(true);
+            final var bookmarkRequest = 레시피저장요청_생성(true);
             assertThatThrownBy(() -> recipeService.bookmarkRecipe(wrongMemberId, recipeId, bookmarkRequest))
                     .isInstanceOf(MemberNotFoundException.class);
         }
 
         @Test
-        void 멤버가_존재하지_않는_레시피에_북마크를_하면_예외가_발생한다() {
+        void 멤버가_존재하지_않는_레시피를_저장하면_예외가_발생한다() {
             // given
             final var member = 멤버_멤버1_생성();
             final var memberId = 단일_멤버_저장(member);
@@ -784,7 +784,7 @@ class RecipeServiceTest extends ServiceTest {
             final var wrongRecipeId = 999L;
 
             // when & then
-            final var bookmarkRequest = 레시피북마크요청_생성(true);
+            final var bookmarkRequest = 레시피저장요청_생성(true);
             assertThatThrownBy(() -> recipeService.bookmarkRecipe(memberId, wrongRecipeId, bookmarkRequest))
                     .isInstanceOf(RecipeNotFoundException.class);
         }
@@ -814,7 +814,7 @@ class RecipeServiceTest extends ServiceTest {
             final var productRecipe2 = 레시피_안에_들어가는_상품_생성(product2, recipe2);
             복수_꿀조합_상품_저장(productRecipe1, productRecipe2);
 
-            final var request = 레시피북마크요청_생성(북마크O);
+            final var request = 레시피저장요청_생성(저장O);
             recipeService.bookmarkRecipe(member1.getId(), recipe2.getId(), request);
 
             final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);

--- a/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
+++ b/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
@@ -16,11 +16,11 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점3점_생성;
 import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
-import static com.funeat.fixture.RecipeFixture.레시피_북마크_생성;
+import static com.funeat.fixture.RecipeFixture.레시피_저장_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_생성;
 import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
-import static com.funeat.fixture.RecipeFixture.북마크O;
-import static com.funeat.fixture.RecipeFixture.북마크X;
+import static com.funeat.fixture.RecipeFixture.저장O;
+import static com.funeat.fixture.RecipeFixture.저장X;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.RepositoryTest;
@@ -364,10 +364,10 @@ class RecipeRepositoryTest extends RepositoryTest {
             final var recipe3 = 레시피_생성(member, 100L);
             복수_꿀조합_저장(recipe1, recipe2, recipe3);
 
-            final var bookmarkRecipe1 = 레시피_북마크_생성(member, recipe1, 북마크X);
-            final var bookmarkRecipe2 = 레시피_북마크_생성(member, recipe2, 북마크O);
-            final var bookmarkRecipe3 = 레시피_북마크_생성(member, recipe3, 북마크O);
-            복수_레시피_북마크_저장(bookmarkRecipe1, bookmarkRecipe2, bookmarkRecipe3);
+            final var bookmarkRecipe1 = 레시피_저장_생성(member, recipe1, 저장X);
+            final var bookmarkRecipe2 = 레시피_저장_생성(member, recipe2, 저장O);
+            final var bookmarkRecipe3 = 레시피_저장_생성(member, recipe3, 저장O);
+            복수_저장한_레시피_저장(bookmarkRecipe1, bookmarkRecipe2, bookmarkRecipe3);
 
             final var expected = List.of(recipe3, recipe2);
             final var page = 페이지요청_생성(0, 10, 최신순, 아이디_내림차순);


### PR DESCRIPTION
## Issue

- close #69 

## ✨ 구현한 기능

- [x] `좋아요O`, `좋아요X`를 `저장O`, `저장X`로 교체합니다.
- [x] `레시피북마크요청_생성`의 파라미터명을 `bookmark`로 교체합니다. (현재 `favorite`으로 설정되어 있음)
- [x] 네이밍 규칙을 적용합니다. (영어는 `bookmark`, 한글은 `저장`으로 통일) → 북마크를 저장으로 변경

## 📢 논의하고 싶은 내용

```java
    protected void 복수_저장한_레시피_저장(final RecipeBookmark... recipeBookmarksToSave) {
        final var recipeBookmarks = List.of(recipeBookmarksToSave);

        recipeBookmarkRepository.saveAll(recipeBookmarks);
    }
```

원래 네이밍 규칙이 `복수_레시피_저장_저장`으로 해야하는데 나중에 테스트 코드에 `복수_레시피_저장_저장(...)`가 있으면 무슨 내용인지 몰라서 내부 메서드 코드까지 확인할 것으로 보입니다. 그래서 `복수_레시피_북마크_저장`과 `복수_저장한_레시피_저장`중에 고민하다가 북마크를 걷어내기로 결정해서 `복수_저장한_레시피_저장`로 선택했습니다

## 🎸 기타

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 0.5
